### PR TITLE
Rename project to VueSip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.0] - 2025-11-05
 
 ### Added
-- Initial release of DailVue
+- Initial release of VueSip
 - `useSipConnection` composable for SIP server connection and registration
 - `useSipCall` composable for call management (make, answer, end, reject)
 - `useSipDtmf` composable for sending DTMF tones
@@ -20,4 +20,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive documentation
 - MIT License
 
-[0.1.0]: https://github.com/ironyh/DailVue/releases/tag/v0.1.0
+[0.1.0]: https://github.com/ironyh/VueSip/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,14 @@
-# Contributing to DailVue
+# Contributing to VueSip
 
-Thank you for your interest in contributing to DailVue! This document provides guidelines and instructions for contributing.
+Thank you for your interest in contributing to VueSip! This document provides guidelines and instructions for contributing.
 
 ## Development Setup
 
 1. Fork the repository
 2. Clone your fork:
    ```bash
-   git clone https://github.com/YOUR_USERNAME/DailVue.git
-   cd DailVue
+   git clone https://github.com/YOUR_USERNAME/VueSip.git
+   cd VueSip
    ```
 
 3. Install dependencies:

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 DailVue Contributors
+Copyright (c) 2025 VueSip Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# DailVue
+# VueSip
 
 Headless Vue components that makes it possible to create great working SIP interfaces!
 
-DailVue provides a set of powerful, headless Vue 3 composables for building SIP (Session Initiation Protocol) interfaces with Asterisk and other VoIP systems. Built with TypeScript and designed for flexibility, DailVue gives you the business logic while letting you control the UI.
+VueSip provides a set of powerful, headless Vue 3 composables for building SIP (Session Initiation Protocol) interfaces with Asterisk and other VoIP systems. Built with TypeScript and designed for flexibility, VueSip gives you the business logic while letting you control the UI.
 
 ## Features
 
@@ -16,17 +16,17 @@ DailVue provides a set of powerful, headless Vue 3 composables for building SIP 
 ⚡ **Modern Stack** - Vue 3, Vite, TypeScript  
 > A headless Vue.js component library for SIP/VoIP applications
 
-[![npm version](https://img.shields.io/npm/v/dailvue.svg)](https://www.npmjs.com/package/dailvue)
+[![npm version](https://img.shields.io/npm/v/vuesip.svg)](https://www.npmjs.com/package/vuesip)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 ## Installation
 
 ```bash
-npm install dailvue
+npm install vuesip
 # or
-yarn add dailvue
+yarn add vuesip
 # or
-pnpm add dailvue
+pnpm add vuesip
 ```
 
 ## Quick Start
@@ -34,7 +34,7 @@ pnpm add dailvue
 ```vue
 <script setup>
 import { ref } from 'vue'
-import { useSipConnection, useSipCall } from 'dailvue'
+import { useSipConnection, useSipCall } from 'vuesip'
 
 const config = {
   server: 'sip.example.com',
@@ -62,7 +62,7 @@ await makeCall('2000')
 Manages SIP server connection and registration.
 
 ```typescript
-import { useSipConnection } from 'dailvue'
+import { useSipConnection } from 'vuesip'
 
 const {
   isConnected,      // Ref<boolean> - Connection state
@@ -94,7 +94,7 @@ interface SipConfig {
 Manages call state and operations.
 
 ```typescript
-import { useSipCall } from 'dailvue'
+import { useSipCall } from 'vuesip'
 
 const {
   currentCall,      // Ref<CallSession | null> - Active call
@@ -127,7 +127,7 @@ interface CallSession {
 Send DTMF (dialpad) tones during calls.
 
 ```typescript
-import { useSipDtmf } from 'dailvue'
+import { useSipDtmf } from 'vuesip'
 
 const {
   sendDtmf,         // (digit: string) => Promise<void> - Send single digit
@@ -146,7 +146,7 @@ await sendDtmfSequence('1234', 160)
 Manage audio input/output devices.
 
 ```typescript
-import { useAudioDevices } from 'dailvue'
+import { useAudioDevices } from 'vuesip'
 
 const {
   audioInputDevices,      // Ref<AudioDevice[]> - Available microphones
@@ -161,7 +161,7 @@ const {
 
 ## Example Components
 
-DailVue includes example components built with PrimeVue to demonstrate usage:
+VueSip includes example components built with PrimeVue to demonstrate usage:
 
 ### Dialpad Component
 
@@ -223,7 +223,7 @@ Requires WebRTC support.
 
 ## Architecture
 
-DailVue follows the headless component pattern:
+VueSip follows the headless component pattern:
 
 1. **Composables** provide the business logic and state management
 2. **You** provide the UI components and styling
@@ -234,13 +234,13 @@ DailVue follows the headless component pattern:
 Full TypeScript support with exported types:
 
 ```typescript
-import type { 
-  SipConfig, 
-  CallSession, 
-  CallState, 
-  AudioDevice, 
-  SipError 
-} from 'dailvue'
+import type {
+  SipConfig,
+  CallSession,
+  CallState,
+  AudioDevice,
+  SipError
+} from 'vuesip'
 ```
 
 ## License
@@ -259,28 +259,28 @@ Built with:
 - [TypeScript](https://www.typescriptlang.org/)
 - [Vite](https://vitejs.dev/)
 # npm
-npm install dailvue
+npm install vuesip
 
 # pnpm
-pnpm add dailvue
+pnpm add vuesip
 
 # yarn
-yarn add dailvue
+yarn add vuesip
 ```
 
 ## Quick Start
 
 ```typescript
-import { createDailVue } from 'dailvue'
+import { createVueSip } from 'vuesip'
 import { createApp } from 'vue'
 
 const app = createApp(App)
-app.use(createDailVue())
+app.use(createVueSip())
 ```
 
 ## Documentation
 
-Full documentation is available at [https://dailvue.dev](https://dailvue.dev) (coming soon)
+Full documentation is available at [https://vuesip.dev](https://vuesip.dev) (coming soon)
 
 ## Browser Support
 

--- a/STATE.md
+++ b/STATE.md
@@ -1,9 +1,9 @@
-# DailVue - Development State Tracker
+# VueSip - Development State Tracker
 
 Version: 1.0.0
 Last Updated: 2025-11-05
 
-This document tracks the implementation progress of DailVue, a headless Vue.js component library for SIP/VoIP applications. Each task is designed to be completed sequentially, building upon previous work.
+This document tracks the implementation progress of VueSip, a headless Vue.js component library for SIP/VoIP applications. Each task is designed to be completed sequentially, building upon previous work.
 
 ## Status Legend
 
@@ -19,7 +19,7 @@ This document tracks the implementation progress of DailVue, a headless Vue.js c
 ### 1.1 Project Setup
 
 - [x] Initialize npm/pnpm package with package.json
-  - Configure package name: "dailvue"
+  - Configure package name: "vuesip"
   - Set version: "1.0.0"
   - Define type: "module"
   - Add Vue 3.4+ as peer dependency

--- a/TECHNICAL_SPECIFICATIONS.md
+++ b/TECHNICAL_SPECIFICATIONS.md
@@ -1,4 +1,4 @@
-# DailVue - Technical Specifications
+# VueSip - Technical Specifications
 ## Vue SIP Headless Components Library
 
 Version: 1.0.0
@@ -32,7 +32,7 @@ Last Updated: 2025-11-05
 ## 1. Project Overview
 
 ### 1.1 Purpose
-DailVue is a headless Vue.js component library providing SIP (Session Initiation Protocol) functionality for building VoIP applications. The library follows the headless UI pattern, separating business logic from presentation, allowing developers to implement custom UI while leveraging robust SIP communication features.
+VueSip is a headless Vue.js component library providing SIP (Session Initiation Protocol) functionality for building VoIP applications. The library follows the headless UI pattern, separating business logic from presentation, allowing developers to implement custom UI while leveraging robust SIP communication features.
 
 ### 1.2 Goals
 - Provide headless components that manage SIP call state without prescribing UI

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vitepress'
 
 export default defineConfig({
-  title: 'DailVue',
+  title: 'VueSip',
   description: 'A headless Vue.js component library for SIP/VoIP applications',
   base: '/',
 
@@ -19,7 +19,7 @@ export default defineConfig({
         {
           text: 'Introduction',
           items: [
-            { text: 'What is DailVue?', link: '/guide/' },
+            { text: 'What is VueSip?', link: '/guide/' },
             { text: 'Getting Started', link: '/guide/getting-started' },
             { text: 'Installation', link: '/guide/installation' },
           ],
@@ -46,7 +46,7 @@ export default defineConfig({
     },
 
     socialLinks: [
-      { icon: 'github', link: 'https://github.com/ironyh/DailVue' },
+      { icon: 'github', link: 'https://github.com/ironyh/VueSip' },
     ],
 
     search: {

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 layout: home
 
 hero:
-  name: DailVue
+  name: VueSip
   text: Headless SIP/VoIP for Vue
   tagline: A modern, type-safe Vue.js component library for building SIP/VoIP applications
   actions:
@@ -11,7 +11,7 @@ hero:
       link: /guide/getting-started
     - theme: alt
       text: View on GitHub
-      link: https://github.com/ironyh/DailVue
+      link: https://github.com/ironyh/VueSip
 
 features:
   - icon: 🎯

--- a/examples/App.vue
+++ b/examples/App.vue
@@ -1,7 +1,7 @@
 <template>
   <div id="app">
     <div class="container">
-      <h1>DailVue - SIP Interface</h1>
+      <h1>VueSip - SIP Interface</h1>
 
       <!-- Connection Status -->
       <div class="status-bar">

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
-# DailVue Examples
+# VueSip Examples
 
-This directory contains example implementations showing how to use DailVue headless Vue composables.
+This directory contains example implementations showing how to use VueSip headless Vue composables.
 
 ## Running the Example
 
@@ -44,7 +44,7 @@ The main example (`App.vue`) demonstrates a complete SIP phone interface with:
 
 ```vue
 <script setup>
-import { useSipConnection } from 'dailvue'
+import { useSipConnection } from 'vuesip'
 
 const config = {
   server: 'sip.example.com',
@@ -65,7 +65,7 @@ await connect()
 ```vue
 <script setup>
 import { ref } from 'vue'
-import { useSipCall } from 'dailvue'
+import { useSipCall } from 'vuesip'
 
 const userAgent = ref(null) // Set this to your UserAgent instance
 const { currentCall, makeCall, endCall } = useSipCall(userAgent)
@@ -86,7 +86,7 @@ const hangup = async () => {
 
 ```vue
 <script setup>
-import { useSipCall } from 'dailvue'
+import { useSipCall } from 'vuesip'
 
 const userAgent = ref(null)
 const { incomingCall, answerCall, rejectCall } = useSipCall(userAgent)
@@ -120,7 +120,7 @@ const reject = async () => {
 ```vue
 <script setup>
 import { ref } from 'vue'
-import { useSipDtmf } from 'dailvue'
+import { useSipDtmf } from 'vuesip'
 
 const currentSession = ref(null) // Set this to your active session
 const { sendDtmf, sendDtmfSequence } = useSipDtmf(currentSession)
@@ -141,7 +141,7 @@ const sendNumber = async () => {
 
 ```vue
 <script setup>
-import { useAudioDevices } from 'dailvue'
+import { useAudioDevices } from 'vuesip'
 
 const {
   audioInputDevices,
@@ -187,7 +187,7 @@ The example components (`Dialpad.vue` and `CallControls.vue`) are provided as re
 <script setup>
 import { Button } from 'primevue/button'
 import { InputText } from 'primevue/inputtext'
-import { useSipConnection, useSipCall } from 'dailvue'
+import { useSipConnection, useSipCall } from 'vuesip'
 
 // Your SIP logic here
 </script>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <link rel="icon" type="image/svg+xml" href="/vite.svg">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>DailVue - SIP Interface Example</title>
+    <title>VueSip - SIP Interface Example</title>
   </head>
   <body>
     <div id="app"></div>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "dailvue",
+  "name": "vuesip",
   "version": "1.0.0",
   "description": "A headless Vue.js component library for SIP/VoIP applications",
   "type": "module",
@@ -17,13 +17,13 @@
     "asterisk",
     "dialpad"
   ],
-  "main": "./dist/dailvue.cjs",
-  "module": "./dist/dailvue.js",
+  "main": "./dist/vuesip.cjs",
+  "module": "./dist/vuesip.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/dailvue.js",
-      "require": "./dist/dailvue.cjs",
+      "import": "./dist/vuesip.js",
+      "require": "./dist/vuesip.cjs",
       "types": "./dist/index.d.ts"
     }
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ export type {
   SipError 
 } from './types'
 /**
- * DailVue - A headless Vue.js component library for SIP/VoIP applications
+ * VueSip - A headless Vue.js component library for SIP/VoIP applications
  * @packageDocumentation
  */
 
@@ -46,16 +46,16 @@ export type {
 export const version = '1.0.0'
 
 // Library initialization
-export interface DailVueOptions {
+export interface VueSipOptions {
   // Global configuration options will be defined here
 }
 
-export function createDailVue(options?: DailVueOptions) {
+export function createVueSip(options?: VueSipOptions) {
   // Vue plugin install method will be implemented here
   return {
     install: () => {
       // Plugin installation logic
-      console.log('DailVue initialized', options)
+      console.log('VueSip initialized', options)
     },
   }
 }

--- a/src/types/config.types.ts
+++ b/src/types/config.types.ts
@@ -1,5 +1,5 @@
 /**
- * Configuration type definitions for DailVue
+ * Configuration type definitions for VueSip
  * @packageDocumentation
  */
 

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,7 +1,7 @@
 /**
- * DailVue Constants
+ * VueSip Constants
  *
- * Centralized constants and default values for the DailVue library.
+ * Centralized constants and default values for the VueSip library.
  * These constants are used throughout the library for SIP configuration,
  * media settings, timeouts, and protocol defaults.
  *
@@ -17,7 +17,7 @@ export const VERSION = '1.0.0'
  * Default User-Agent string format
  * Used in SIP headers to identify the client
  */
-export const USER_AGENT = `DailVue/${VERSION}`
+export const USER_AGENT = `VueSip/${VERSION}`
 
 // ============================================================================
 // SIP Configuration Defaults

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -1,5 +1,5 @@
 /**
- * DailVue Formatters
+ * VueSip Formatters
  *
  * Formatting functions for SIP URIs, durations, phone numbers, and dates.
  * These utilities help display data in user-friendly formats.

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,5 +1,5 @@
 /**
- * DailVue Utilities
+ * VueSip Utilities
  *
  * Centralized export of all utility functions, constants, and helpers.
  *

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,8 +1,8 @@
 /**
- * DailVue Logger
+ * VueSip Logger
  *
  * Configurable logging system with namespace support, log levels, and browser console formatting.
- * Provides consistent logging throughout the DailVue library with the ability to filter by level and namespace.
+ * Provides consistent logging throughout the VueSip library with the ability to filter by level and namespace.
  *
  * @module utils/logger
  */

--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -1,5 +1,5 @@
 /**
- * DailVue Validators
+ * VueSip Validators
  *
  * Validation functions for SIP URIs, phone numbers, configurations, and other inputs.
  * All validators return a consistent ValidationResult structure.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -22,13 +22,13 @@ export default defineConfig({
   build: {
     lib: {
       entry: resolve(__dirname, 'src/index.ts'),
-      name: 'DailVue',
+      name: 'VueSip',
       formats: ['es', 'cjs', 'umd'],
       fileName: (format) => {
-        if (format === 'es') return 'dailvue.js'
-        if (format === 'cjs') return 'dailvue.cjs'
-        if (format === 'umd') return 'dailvue.umd.js'
-        return `dailvue.${format}.js`
+        if (format === 'es') return 'vuesip.js'
+        if (format === 'cjs') return 'vuesip.cjs'
+        if (format === 'umd') return 'vuesip.umd.js'
+        return `vuesip.${format}.js`
       },
     },
     rollupOptions: {


### PR DESCRIPTION
- Update package name from 'dailvue' to 'vuesip'
- Update all build output filenames (dailvue.js -> vuesip.js, etc.)
- Update project title and branding across all documentation
- Update library name in vite config and source code
- Update GitHub repository references
- Update User-Agent string for SIP headers
- Update TypeScript interface names (DailVueOptions -> VueSipOptions)
- Update function names (createDailVue -> createVueSip)