### PR TITLE
Fix code quality issues from store implementation review

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "dailvue",
+  "name": "vuesip",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "dailvue",
+      "name": "vuesip",
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {

--- a/src/stores/deviceStore.ts
+++ b/src/stores/deviceStore.ts
@@ -59,7 +59,7 @@ const state = reactive<DeviceStoreState>({
 /**
  * Computed values
  */
-const computed_values: Record<string, any> = {
+const computed_values = {
   /** Total number of available devices */
   totalDevices: computed(
     () =>

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,7 +1,7 @@
 /**
  * Store exports
  *
- * Central export point for all DailVue stores.
+ * Central export point for all VueSip stores.
  *
  * @module stores
  */

--- a/src/stores/registrationStore.ts
+++ b/src/stores/registrationStore.ts
@@ -53,7 +53,7 @@ const state = reactive<RegistrationStoreState>({
 /**
  * Computed values
  */
-const computed_values: Record<string, any> = {
+const computed_values = {
   /** Whether currently registered */
   isRegistered: computed(() => state.state === RegistrationState.Registered),
 
@@ -75,7 +75,7 @@ const computed_values: Record<string, any> = {
   }),
 
   /** Whether registration is about to expire (less than 30 seconds) */
-  isExpiringsSoon: computed(() => computed_values.secondsUntilExpiry.value < 30),
+  isExpiringSoon: computed(() => computed_values.secondsUntilExpiry.value < 30),
 
   /** Whether registration has expired */
   hasExpired: computed(() => computed_values.secondsUntilExpiry.value === 0),
@@ -179,7 +179,7 @@ export const registrationStore = {
    * Check if expiring soon
    */
   get isExpiringSoon() {
-    return computed_values.isExpiringsSoon.value
+    return computed_values.isExpiringSoon.value
   },
 
   /**

--- a/src/types/config.types.ts
+++ b/src/types/config.types.ts
@@ -66,7 +66,7 @@ export interface UserPreferences {
 }
 
 /**
- * Extended RTCConfiguration with DailVue-specific options
+ * Extended RTCConfiguration with VueSip-specific options
  */
 export interface ExtendedRTCConfiguration extends RTCConfiguration {
   /** STUN server URLs */

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -283,10 +283,10 @@ export const EVENTS = {
 // ============================================================================
 
 /**
- * LocalStorage key prefix for DailVue
+ * LocalStorage key prefix for VueSip
  * All keys are namespaced to avoid conflicts
  */
-export const STORAGE_PREFIX = 'dailvue:'
+export const STORAGE_PREFIX = 'vuesip:'
 
 /**
  * Storage version for migration support

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -391,4 +391,4 @@ export function setLogHandler(handler: LogHandler | undefined): void {
 /**
  * Default logger instance (for global use)
  */
-export const defaultLogger = createLogger('DailVue')
+export const defaultLogger = createLogger('VueSip')

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,6 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "allowSyntheticDefaultImports": true,
-    "allowImportingTsExtensions": true,
 
     /* Type Checking */
     "strict": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -33,12 +33,13 @@ export default defineConfig({
     },
     rollupOptions: {
       // Make sure to externalize deps that shouldn't be bundled
-      external: ['vue', 'jssip', 'webrtc-adapter'],
+      external: ['vue', 'jssip', 'sip.js', 'webrtc-adapter'],
       output: {
         // Provide global variables to use in the UMD build
         globals: {
           vue: 'Vue',
           jssip: 'JsSIP',
+          'sip.js': 'SIP',
           'webrtc-adapter': 'adapter',
         },
         // Export format for named exports


### PR DESCRIPTION
- Remove duplicate 'allowImportingTsExtensions' key in tsconfig.json
- Rename all 'DailVue' references to 'VueSip' for consistency
- Update STORAGE_PREFIX from 'dailvue:' to 'vuesip:'
- Fix typo: 'isExpiringsSoon' → 'isExpiringSoon' in registrationStore
- Remove overly permissive 'Record<string, any>' type annotations from computed_values
- Add 'sip.js' to external dependencies in vite config to fix build

These changes improve code consistency, fix TypeScript warnings, and resolve the build failure caused by unresolved sip.js import.