### PR TITLE
feat(composables): add Enhanced WebRTC Stats Phase 2.1 - call quality composables

### DIFF
--- a/playground/PlaygroundApp.vue
+++ b/playground/PlaygroundApp.vue
@@ -846,7 +846,7 @@ watch(isDarkMode, (newValue) => {
   border-radius: 7px;
   font-size: 0.7rem;
   font-weight: 600;
-  color: var(--gray-700);
+  color: var(--text-secondary);
   cursor: pointer;
   transition:
     color 0.2s ease,
@@ -933,7 +933,7 @@ watch(isDarkMode, (newValue) => {
 }
 
 .search-input::placeholder {
-  color: var(--gray-400);
+  color: var(--text-muted);
 }
 
 .clear-search {
@@ -943,7 +943,7 @@ watch(isDarkMode, (newValue) => {
   transform: translateY(-50%);
   background: none;
   border: none;
-  color: var(--gray-500);
+  color: var(--text-muted);
   cursor: pointer;
   padding: 0.25rem 0.5rem;
   font-size: 1.125rem;
@@ -958,10 +958,10 @@ watch(isDarkMode, (newValue) => {
 /* Filter Stats */
 .filter-stats {
   font-size: 0.75rem;
-  color: var(--gray-500);
+  color: var(--text-secondary);
   margin-bottom: 0.75rem;
   padding: 0.5rem;
-  background: var(--gray-100);
+  background: var(--bg-secondary);
   border-radius: 4px;
   text-align: center;
 }
@@ -996,7 +996,7 @@ watch(isDarkMode, (newValue) => {
 .no-results {
   text-align: center;
   padding: 2rem 1rem;
-  color: var(--gray-500);
+  color: var(--text-secondary);
 }
 
 .no-results p {
@@ -1006,9 +1006,9 @@ watch(isDarkMode, (newValue) => {
 
 .btn-secondary {
   padding: 0.5rem 1rem;
-  background: var(--gray-100);
-  color: var(--gray-700);
-  border: 1px solid var(--gray-300);
+  background: var(--bg-secondary);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
   border-radius: 6px;
   font-size: 0.875rem;
   cursor: pointer;
@@ -1016,7 +1016,7 @@ watch(isDarkMode, (newValue) => {
 }
 
 .btn-secondary:hover {
-  background: var(--gray-200);
+  background: var(--border-color);
 }
 
 .example-list {

--- a/playground/style.css
+++ b/playground/style.css
@@ -52,8 +52,10 @@
   /* Semantic Colors (Light Theme) */
   --bg-primary: #ffffff;
   --bg-secondary: #f8f9fa;
+  --bg-card: #ffffff;
   --text-primary: #111827;
   --text-secondary: #6b7280;
+  --text-muted: #9ca3af;
   --border-color: #e5e7eb;
 }
 
@@ -83,8 +85,10 @@
   /* Semantic Colors (Dark Theme) */
   --bg-primary: #111827;
   --bg-secondary: #1f2937;
+  --bg-card: #1f2937;
   --text-primary: #f9fafb;
   --text-secondary: #d1d5db;
+  --text-muted: #9ca3af;
   --border-color: #374151;
 
   /* Darker Shadows for Dark Mode */

--- a/src/composables/index.ts
+++ b/src/composables/index.ts
@@ -64,6 +64,11 @@ export { useSipSecondLine } from './useSipSecondLine'
 // useSipConnection requires sip.js library - not exported until dual-library support is added
 export { useSipDtmf } from './useSipDtmf'
 
+// Call quality composables
+export { useCallQualityScore } from './useCallQualityScore'
+export { useNetworkQualityIndicator } from './useNetworkQualityIndicator'
+export { useBandwidthAdaptation } from './useBandwidthAdaptation'
+
 // Additional composables
 export { useCallHold } from './useCallHold'
 export { useCallTransfer } from './useCallTransfer'
@@ -104,6 +109,50 @@ export {
 // Re-export types needed by demos
 export type { CallbackPriority, CallbackRequest } from '../types/callback.types'
 export type { BlockReason, BlockAction, BlockEntry } from '../types/blacklist.types'
+
+// Call quality types
+export type {
+  // Quality score types
+  QualityGrade,
+  CallQualityScore,
+  QualityScoreWeights,
+  QualityTrendDirection,
+  QualityTrend,
+  CallQualityScoreOptions,
+  QualityScoreInput,
+  UseCallQualityScoreReturn,
+  // Network quality types
+  NetworkQualityLevel,
+  SignalBars,
+  NetworkQualityIcon,
+  NetworkDetails,
+  NetworkQualityIndicatorData,
+  NetworkQualityColors,
+  NetworkQualityThresholds,
+  NetworkQualityIndicatorOptions,
+  NetworkQualityInput,
+  UseNetworkQualityIndicatorReturn,
+  // Bandwidth adaptation types
+  BandwidthAction,
+  RecommendationPriority,
+  SuggestionType,
+  AdaptationSuggestion,
+  BandwidthRecommendation,
+  VideoResolution,
+  BandwidthConstraints,
+  BandwidthAdaptationOptions,
+  BandwidthAdaptationInput,
+  UseBandwidthAdaptationReturn,
+} from '../types/call-quality.types'
+
+export {
+  // Call quality constants
+  DEFAULT_QUALITY_WEIGHTS,
+  DEFAULT_NETWORK_COLORS,
+  DEFAULT_NETWORK_THRESHOLDS,
+  DEFAULT_BANDWIDTH_CONSTRAINTS,
+  VIDEO_RESOLUTIONS,
+} from '../types/call-quality.types'
 
 // Constants
 export {

--- a/src/composables/useBandwidthAdaptation.ts
+++ b/src/composables/useBandwidthAdaptation.ts
@@ -1,0 +1,586 @@
+/**
+ * useBandwidthAdaptation Composable
+ *
+ * Provides intelligent bandwidth adaptation recommendations for WebRTC connections.
+ * Analyzes available bandwidth, packet loss, RTT, and other metrics to suggest
+ * resolution, framerate, and bitrate adjustments for optimal call quality.
+ *
+ * @example
+ * ```typescript
+ * const { recommendation, update, setConstraints } = useBandwidthAdaptation({
+ *   sensitivity: 0.6,
+ *   onRecommendation: (rec) => console.log('New recommendation:', rec)
+ * })
+ *
+ * // Update with WebRTC stats
+ * update({
+ *   availableBitrate: 1500,
+ *   currentBitrate: 1200,
+ *   packetLoss: 0.5,
+ *   rtt: 50,
+ *   currentResolution: { width: 1280, height: 720, label: '720p' },
+ *   videoEnabled: true
+ * })
+ *
+ * // Check recommendation
+ * if (recommendation.value.action === 'downgrade') {
+ *   // Apply suggestions
+ * }
+ * ```
+ *
+ * @packageDocumentation
+ */
+
+import { ref, computed, type Ref, type ComputedRef } from 'vue'
+import {
+  type BandwidthAction,
+  type RecommendationPriority,
+  type AdaptationSuggestion,
+  type BandwidthRecommendation,
+  type VideoResolution,
+  type BandwidthConstraints,
+  type BandwidthAdaptationOptions,
+  type BandwidthAdaptationInput,
+  type UseBandwidthAdaptationReturn,
+  DEFAULT_BANDWIDTH_CONSTRAINTS,
+  VIDEO_RESOLUTIONS,
+} from '@/types/call-quality.types'
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/**
+ * Thresholds for bandwidth ratio (available/current) to determine action
+ */
+const BANDWIDTH_RATIO_THRESHOLDS = {
+  upgrade: 2.0, // 2x available bandwidth → can upgrade
+  maintain: 0.8, // 80% available → maintain current
+  downgrade: 0.5, // 50% available → should downgrade
+  critical: 0.15, // 15% available → critical
+}
+
+/**
+ * Thresholds for packet loss to determine severity
+ */
+const PACKET_LOSS_THRESHOLDS = {
+  excellent: 0.5,
+  good: 1.5,
+  fair: 3,
+  poor: 5,
+  critical: 8,
+}
+
+/**
+ * Thresholds for RTT to determine severity
+ */
+const RTT_THRESHOLDS = {
+  excellent: 50,
+  good: 100,
+  fair: 200,
+  poor: 350,
+  critical: 500,
+}
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+/**
+ * Clamp a value to a range
+ */
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value))
+}
+
+/**
+ * Clamp to non-negative
+ */
+function clampNonNegative(value: number | undefined): number {
+  return value !== undefined ? Math.max(0, value) : 0
+}
+
+/**
+ * Find next lower resolution from current
+ */
+function findLowerResolution(current: VideoResolution): VideoResolution | null {
+  const currentIndex = VIDEO_RESOLUTIONS.findIndex(
+    (r) => r.width === current.width && r.height === current.height
+  )
+  if (currentIndex === -1 || currentIndex === VIDEO_RESOLUTIONS.length - 1) {
+    return null
+  }
+  return VIDEO_RESOLUTIONS[currentIndex + 1] ?? null
+}
+
+/**
+ * Find next higher resolution from current
+ */
+function findHigherResolution(current: VideoResolution): VideoResolution | null {
+  const currentIndex = VIDEO_RESOLUTIONS.findIndex(
+    (r) => r.width === current.width && r.height === current.height
+  )
+  if (currentIndex <= 0) {
+    return null
+  }
+  return VIDEO_RESOLUTIONS[currentIndex - 1] ?? null
+}
+
+/**
+ * Create default recommendation
+ */
+function createDefaultRecommendation(): BandwidthRecommendation {
+  return {
+    action: 'maintain',
+    suggestions: [],
+    priority: 'low',
+    estimatedImprovement: 0,
+    timestamp: Date.now(),
+  }
+}
+
+// =============================================================================
+// Main Composable
+// =============================================================================
+
+/**
+ * Bandwidth adaptation composable
+ *
+ * @param options - Configuration options
+ * @returns Reactive bandwidth adaptation state and controls
+ */
+export function useBandwidthAdaptation(
+  options: BandwidthAdaptationOptions = {}
+): UseBandwidthAdaptationReturn {
+  // Merge options with defaults
+  const sensitivity = clamp(options.sensitivity ?? 0.5, 0, 1)
+  const historySize = options.historySize ?? 5
+  const onRecommendation = options.onRecommendation
+
+  // State
+  const isAutoAdapting: Ref<boolean> = ref(options.autoAdapt ?? false)
+  const constraints: Ref<Required<BandwidthConstraints>> = ref({
+    ...DEFAULT_BANDWIDTH_CONSTRAINTS,
+    ...options.constraints,
+  })
+
+  // History for smoothing
+  const history: Ref<BandwidthAdaptationInput[]> = ref([])
+
+  // Current recommendation
+  const currentRecommendation: Ref<BandwidthRecommendation> = ref(createDefaultRecommendation())
+
+  // Computed recommendation with proper typing
+  const recommendation: ComputedRef<BandwidthRecommendation> = computed(
+    () => currentRecommendation.value
+  )
+
+  /**
+   * Calculate severity score (0-1) based on metrics
+   */
+  function calculateSeverity(input: BandwidthAdaptationInput): number {
+    const contributions: number[] = []
+
+    // Bandwidth ratio contribution
+    if (input.availableBitrate !== undefined && input.currentBitrate !== undefined) {
+      const ratio =
+        input.currentBitrate > 0
+          ? input.availableBitrate / input.currentBitrate
+          : input.availableBitrate > 0
+            ? 2
+            : 0
+
+      if (ratio <= BANDWIDTH_RATIO_THRESHOLDS.critical) {
+        contributions.push(1.0)
+      } else if (ratio <= BANDWIDTH_RATIO_THRESHOLDS.downgrade) {
+        contributions.push(0.7)
+      } else if (ratio <= BANDWIDTH_RATIO_THRESHOLDS.maintain) {
+        contributions.push(0.4)
+      }
+      // Good bandwidth ratio doesn't contribute to severity
+    }
+
+    // Packet loss contribution
+    if (input.packetLoss !== undefined) {
+      const packetLoss = clampNonNegative(input.packetLoss)
+      if (packetLoss >= PACKET_LOSS_THRESHOLDS.critical) {
+        contributions.push(1.0)
+      } else if (packetLoss >= PACKET_LOSS_THRESHOLDS.poor) {
+        contributions.push(0.7)
+      } else if (packetLoss >= PACKET_LOSS_THRESHOLDS.fair) {
+        contributions.push(0.5)
+      } else if (packetLoss >= PACKET_LOSS_THRESHOLDS.good) {
+        contributions.push(0.3)
+      } else if (packetLoss >= PACKET_LOSS_THRESHOLDS.excellent) {
+        contributions.push(0.15)
+      }
+      // Zero/excellent packet loss doesn't contribute to severity
+    }
+
+    // RTT contribution
+    if (input.rtt !== undefined) {
+      const rtt = clampNonNegative(input.rtt)
+      if (rtt >= RTT_THRESHOLDS.critical) {
+        contributions.push(1.0)
+      } else if (rtt >= RTT_THRESHOLDS.poor) {
+        contributions.push(0.7)
+      } else if (rtt >= RTT_THRESHOLDS.fair) {
+        contributions.push(0.5)
+      } else if (rtt >= RTT_THRESHOLDS.good) {
+        contributions.push(0.3)
+      }
+      // Excellent RTT doesn't contribute to severity
+    }
+
+    // Degradation events contribution
+    if (input.degradationEvents !== undefined && input.degradationEvents > 0) {
+      contributions.push(Math.min(input.degradationEvents * 0.1, 0.5))
+    }
+
+    // Handle edge case of no severity-contributing metrics
+    if (contributions.length === 0) {
+      return 0
+    }
+
+    // Use max contribution for more responsive severity detection
+    // This makes the system react to the worst metric
+    const maxContribution = Math.max(...contributions)
+    const avgContribution = contributions.reduce((a, b) => a + b, 0) / contributions.length
+
+    // Blend max and average (weighted toward max for responsiveness)
+    const baseSeverity = maxContribution * 0.6 + avgContribution * 0.4
+
+    // Apply sensitivity scaling
+    return baseSeverity * (0.5 + sensitivity * 0.5)
+  }
+
+  /**
+   * Determine action based on severity and metrics
+   */
+  function determineAction(input: BandwidthAdaptationInput, severity: number): BandwidthAction {
+    // Critical conditions - lowered threshold to account for sensitivity scaling
+    if (severity >= 0.7) {
+      return 'critical'
+    }
+
+    // Check for zero/negative bitrates
+    const available = clampNonNegative(input.availableBitrate)
+    const current = clampNonNegative(input.currentBitrate)
+
+    if (available === 0 && current === 0) {
+      return 'critical'
+    }
+
+    // Downgrade conditions
+    if (severity >= 0.4) {
+      return 'downgrade'
+    }
+
+    // Check for upgrade opportunity
+    if (
+      available > 0 &&
+      current > 0 &&
+      available / current >= BANDWIDTH_RATIO_THRESHOLDS.upgrade &&
+      severity < 0.2
+    ) {
+      return 'upgrade'
+    }
+
+    // Default to maintain
+    return 'maintain'
+  }
+
+  /**
+   * Determine priority based on severity
+   */
+  function determinePriority(severity: number, action: BandwidthAction): RecommendationPriority {
+    if (action === 'critical' || severity >= 0.7) {
+      return 'critical'
+    }
+    if (severity >= 0.4) {
+      return 'high'
+    }
+    if (severity >= 0.25) {
+      return 'medium'
+    }
+    return 'low'
+  }
+
+  /**
+   * Generate suggestions based on current conditions
+   */
+  function generateSuggestions(
+    input: BandwidthAdaptationInput,
+    action: BandwidthAction
+  ): AdaptationSuggestion[] {
+    const suggestions: AdaptationSuggestion[] = []
+
+    // No suggestions for maintain
+    if (action === 'maintain') {
+      return suggestions
+    }
+
+    const videoEnabled = input.videoEnabled !== false
+    const availableBitrate = input.availableBitrate ?? 0
+
+    // Video-related suggestions
+    if (videoEnabled) {
+      // Check if bandwidth is below minimum video bitrate - suggest disabling video
+      if (availableBitrate > 0 && availableBitrate < constraints.value.minVideoBitrate) {
+        suggestions.push({
+          type: 'video',
+          message: 'Disable video - insufficient bandwidth for minimum quality',
+          current: 'Video enabled',
+          recommended: 'Audio only',
+          impact: 75,
+        })
+      } else if (action === 'critical') {
+        // Suggest disabling video
+        suggestions.push({
+          type: 'video',
+          message: 'Disable video and switch to audio-only call',
+          current: 'Video enabled',
+          recommended: 'Audio only',
+          impact: 80,
+        })
+      } else if (action === 'downgrade') {
+        // Suggest resolution downgrade if resolution is provided
+        if (input.currentResolution) {
+          const lowerRes = findLowerResolution(input.currentResolution)
+          if (lowerRes) {
+            suggestions.push({
+              type: 'video',
+              message: `Reduce video resolution from ${input.currentResolution.label} to ${lowerRes.label}`,
+              current: input.currentResolution.label,
+              recommended: lowerRes.label,
+              impact: 50,
+            })
+          }
+        }
+
+        // Suggest framerate reduction - works even without resolution
+        if (input.currentFramerate && input.currentFramerate > constraints.value.minFramerate) {
+          const targetFramerate = Math.max(
+            constraints.value.minFramerate,
+            Math.floor(input.currentFramerate * 0.6)
+          )
+          suggestions.push({
+            type: 'video',
+            message: `Reduce framerate from ${input.currentFramerate}fps to ${targetFramerate}fps`,
+            current: `${input.currentFramerate}fps`,
+            recommended: `${targetFramerate}fps`,
+            impact: 30,
+          })
+        }
+      } else if (action === 'upgrade' && input.currentResolution) {
+        // Suggest resolution upgrade
+        const higherRes = findHigherResolution(input.currentResolution)
+        if (higherRes) {
+          suggestions.push({
+            type: 'video',
+            message: `Increase video resolution from ${input.currentResolution.label} to ${higherRes.label}`,
+            current: input.currentResolution.label,
+            recommended: higherRes.label,
+            impact: 40,
+          })
+        }
+      }
+    }
+
+    // Audio-related suggestions
+    if (
+      input.currentAudioBitrate !== undefined &&
+      input.currentAudioBitrate > constraints.value.minAudioBitrate
+    ) {
+      if (action === 'downgrade' || action === 'critical') {
+        const targetAudioBitrate = Math.max(
+          constraints.value.minAudioBitrate,
+          Math.floor(input.currentAudioBitrate * 0.5)
+        )
+        if (targetAudioBitrate < input.currentAudioBitrate) {
+          suggestions.push({
+            type: 'audio',
+            message: `Reduce audio bitrate from ${input.currentAudioBitrate}kbps to ${targetAudioBitrate}kbps`,
+            current: `${input.currentAudioBitrate}kbps`,
+            recommended: `${targetAudioBitrate}kbps`,
+            impact: 20,
+          })
+        }
+      }
+    }
+
+    // Sort by impact (highest first)
+    suggestions.sort((a, b) => b.impact - a.impact)
+
+    return suggestions
+  }
+
+  /**
+   * Calculate estimated improvement from suggestions
+   */
+  function calculateEstimatedImprovement(
+    suggestions: AdaptationSuggestion[],
+    action: BandwidthAction
+  ): number {
+    if (action === 'maintain' || suggestions.length === 0) {
+      return 0
+    }
+
+    // Sum impacts with diminishing returns
+    let improvement = 0
+    let factor = 1.0
+    for (const suggestion of suggestions) {
+      improvement += suggestion.impact * factor
+      factor *= 0.6 // Diminishing returns
+    }
+
+    return Math.min(100, Math.round(improvement))
+  }
+
+  /**
+   * Get smoothed input from history
+   */
+  function getSmoothedInput(): BandwidthAdaptationInput {
+    if (history.value.length === 0) {
+      return {}
+    }
+
+    // Use most recent values, but average some metrics
+    const recent = history.value[history.value.length - 1]!
+
+    // Average packet loss and RTT over history for smoothing
+    let avgPacketLoss = 0
+    let avgRtt = 0
+    let plCount = 0
+    let rttCount = 0
+
+    for (const h of history.value) {
+      if (h.packetLoss !== undefined) {
+        avgPacketLoss += h.packetLoss
+        plCount++
+      }
+      if (h.rtt !== undefined) {
+        avgRtt += h.rtt
+        rttCount++
+      }
+    }
+
+    return {
+      ...recent,
+      packetLoss: plCount > 0 ? avgPacketLoss / plCount : recent.packetLoss,
+      rtt: rttCount > 0 ? avgRtt / rttCount : recent.rtt,
+    }
+  }
+
+  /**
+   * Update with new network statistics
+   */
+  function update(input: BandwidthAdaptationInput): void {
+    // Check for empty input
+    const hasMetrics =
+      input.availableBitrate !== undefined ||
+      input.currentBitrate !== undefined ||
+      input.packetLoss !== undefined ||
+      input.rtt !== undefined ||
+      input.degradationEvents !== undefined
+
+    if (!hasMetrics) {
+      // Empty update - maintain current state
+      currentRecommendation.value = {
+        ...currentRecommendation.value,
+        timestamp: Date.now(),
+      }
+      return
+    }
+
+    // Add to history
+    history.value.push({ ...input })
+    if (history.value.length > historySize) {
+      history.value.shift()
+    }
+
+    // Get smoothed input
+    const smoothedInput = getSmoothedInput()
+
+    // Calculate severity
+    const severity = calculateSeverity(smoothedInput)
+
+    // Determine action
+    const action = determineAction(smoothedInput, severity)
+
+    // Determine priority
+    const priority = determinePriority(severity, action)
+
+    // Generate suggestions
+    const suggestions = generateSuggestions(input, action)
+
+    // Calculate estimated improvement
+    const estimatedImprovement = calculateEstimatedImprovement(suggestions, action)
+
+    // Create new recommendation
+    const newRecommendation: BandwidthRecommendation = {
+      action,
+      suggestions,
+      priority,
+      estimatedImprovement,
+      timestamp: Date.now(),
+    }
+
+    // Update state
+    currentRecommendation.value = newRecommendation
+
+    // Call callback if provided
+    if (onRecommendation) {
+      onRecommendation(newRecommendation)
+    }
+  }
+
+  /**
+   * Enable or disable auto-adaptation
+   */
+  function setAutoAdapt(enabled: boolean): void {
+    isAutoAdapting.value = enabled
+  }
+
+  /**
+   * Update constraints
+   */
+  function setConstraints(newConstraints: Partial<BandwidthConstraints>): void {
+    constraints.value = {
+      ...constraints.value,
+      ...newConstraints,
+    }
+  }
+
+  /**
+   * Reset to default state
+   */
+  function reset(): void {
+    isAutoAdapting.value = false
+    constraints.value = { ...DEFAULT_BANDWIDTH_CONSTRAINTS }
+    history.value = []
+    currentRecommendation.value = createDefaultRecommendation()
+  }
+
+  /**
+   * Apply a specific suggestion (placeholder for integration)
+   */
+  function applySuggestion(_suggestion: AdaptationSuggestion): void {
+    // This is a placeholder for integrating with actual media controls
+    // In a real implementation, this would:
+    // - For video suggestions: call RTCRtpSender.setParameters() or renegotiate
+    // - For audio suggestions: adjust audio encoder settings
+    // - For codec suggestions: trigger codec renegotiation
+  }
+
+  return {
+    recommendation,
+    isAutoAdapting,
+    constraints,
+    update,
+    setAutoAdapt,
+    setConstraints,
+    reset,
+    applySuggestion,
+  }
+}

--- a/src/composables/useCallQualityScore.ts
+++ b/src/composables/useCallQualityScore.ts
@@ -1,0 +1,526 @@
+/**
+ * useCallQualityScore Composable
+ *
+ * Provides comprehensive call quality scoring by combining multiple WebRTC metrics
+ * into a single quality score with trend analysis and history tracking.
+ *
+ * @packageDocumentation
+ */
+
+import { ref, type Ref } from 'vue'
+import type {
+  CallQualityScore,
+  QualityGrade,
+  QualityScoreWeights,
+  QualityTrend,
+  QualityTrendDirection,
+  CallQualityScoreOptions,
+  QualityScoreInput,
+  UseCallQualityScoreReturn,
+} from '@/types/call-quality.types'
+import { DEFAULT_QUALITY_WEIGHTS } from '@/types/call-quality.types'
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/** Thresholds for each metric (values above these are considered bad) */
+const METRIC_THRESHOLDS = {
+  packetLoss: { excellent: 0.5, good: 1, fair: 2, poor: 5 },
+  jitter: { excellent: 10, good: 20, fair: 40, poor: 80 },
+  rtt: { excellent: 50, good: 100, fair: 200, poor: 400 },
+  audioJitterBufferDelay: { excellent: 20, good: 40, fair: 80, poor: 150 },
+}
+
+/** Grade thresholds */
+const GRADE_THRESHOLDS = {
+  A: 90,
+  B: 75,
+  C: 60,
+  D: 40,
+}
+
+/** Minimum history entries needed for confident trend analysis */
+const MIN_TREND_ENTRIES = 3
+
+/** Threshold for considering a trend stable vs changing */
+const TREND_STABILITY_THRESHOLD = 0.5 // Score points per interval (lower threshold for sensitivity)
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+/**
+ * Clamp a value between min and max
+ */
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value))
+}
+
+/**
+ * Calculate a metric score (0-100) based on value and thresholds
+ * Lower values are better for most metrics
+ */
+function calculateMetricScore(
+  value: number | undefined,
+  thresholds: { excellent: number; good: number; fair: number; poor: number },
+  defaultScore: number = 100 // Default to perfect when unavailable (doesn't penalize)
+): number {
+  if (value === undefined || value === null) {
+    return defaultScore
+  }
+
+  // Clamp negative values to 0
+  const clampedValue = Math.max(0, value)
+
+  if (clampedValue <= thresholds.excellent) {
+    return 100
+  } else if (clampedValue <= thresholds.good) {
+    // Linear interpolation between 100 and 85
+    const ratio = (clampedValue - thresholds.excellent) / (thresholds.good - thresholds.excellent)
+    return 100 - ratio * 15
+  } else if (clampedValue <= thresholds.fair) {
+    // Linear interpolation between 85 and 65
+    const ratio = (clampedValue - thresholds.good) / (thresholds.fair - thresholds.good)
+    return 85 - ratio * 20
+  } else if (clampedValue <= thresholds.poor) {
+    // Linear interpolation between 65 and 40
+    const ratio = (clampedValue - thresholds.fair) / (thresholds.poor - thresholds.fair)
+    return 65 - ratio * 25
+  } else {
+    // Below poor threshold, scale down to minimum
+    const ratio = Math.min(1, (clampedValue - thresholds.poor) / thresholds.poor)
+    return Math.max(0, 40 - ratio * 40)
+  }
+}
+
+/**
+ * Calculate MOS-based score (MOS is 1-5, higher is better)
+ */
+function calculateMosScore(mos: number | undefined): number {
+  if (mos === undefined || mos === null) {
+    return 100 // Default to perfect when unavailable (doesn't penalize)
+  }
+
+  // Clamp MOS to valid range
+  const clampedMos = clamp(mos, 1, 5)
+
+  // Convert MOS (1-5) to score (0-100)
+  // MOS 5 = 100, MOS 4 = 80, MOS 3 = 60, MOS 2 = 40, MOS 1 = 0
+  return ((clampedMos - 1) / 4) * 100
+}
+
+/**
+ * Calculate bitrate stability score (0-100)
+ */
+function calculateBitrateStabilityScore(
+  bitrate: number | undefined,
+  previousBitrate: number | undefined
+): number {
+  if (bitrate === undefined || previousBitrate === undefined) {
+    return 100 // Default to perfect when unavailable (doesn't penalize)
+  }
+
+  if (previousBitrate === 0) {
+    return bitrate > 0 ? 100 : 50
+  }
+
+  // Calculate percentage change
+  const change = Math.abs(bitrate - previousBitrate) / previousBitrate
+
+  // No change = 100, 10% change = 90, 50% change = 50, 100%+ change = 0
+  if (change <= 0.05) {
+    return 100
+  } else if (change <= 0.1) {
+    return 90 + (0.1 - change) * 200
+  } else if (change <= 0.5) {
+    return 90 - (change - 0.1) * 100
+  } else {
+    return Math.max(0, 50 - (change - 0.5) * 100)
+  }
+}
+
+/**
+ * Calculate framerate score
+ */
+function calculateFramerateScore(
+  framerate: number | undefined,
+  targetFramerate: number | undefined
+): number {
+  if (framerate === undefined) {
+    return 50
+  }
+
+  const target = targetFramerate ?? 30
+  const ratio = framerate / target
+
+  if (ratio >= 1) {
+    return 100
+  } else if (ratio >= 0.9) {
+    return 95
+  } else if (ratio >= 0.75) {
+    return 85
+  } else if (ratio >= 0.5) {
+    return 65
+  } else {
+    return Math.max(0, ratio * 100)
+  }
+}
+
+/**
+ * Calculate resolution score based on standard resolutions
+ */
+function calculateResolutionScore(width: number | undefined, height: number | undefined): number {
+  if (width === undefined || height === undefined) {
+    return 50
+  }
+
+  const pixels = width * height
+
+  // Reference: 1080p = 2,073,600, 720p = 921,600, 480p = 409,920, 360p = 230,400
+  if (pixels >= 2000000) return 100 // 1080p+
+  if (pixels >= 900000) return 90 // 720p
+  if (pixels >= 400000) return 75 // 480p
+  if (pixels >= 200000) return 60 // 360p
+  if (pixels >= 100000) return 45 // 240p
+  return Math.max(20, (pixels / 100000) * 45)
+}
+
+/**
+ * Calculate freeze penalty score
+ */
+function calculateFreezeScore(freezeCount: number | undefined): number {
+  if (freezeCount === undefined || freezeCount === 0) {
+    return 100
+  }
+
+  // Each freeze reduces score by 15 points
+  return Math.max(0, 100 - freezeCount * 15)
+}
+
+/**
+ * Determine quality grade from overall score
+ */
+function getGrade(score: number): QualityGrade {
+  if (score >= GRADE_THRESHOLDS.A) return 'A'
+  if (score >= GRADE_THRESHOLDS.B) return 'B'
+  if (score >= GRADE_THRESHOLDS.C) return 'C'
+  if (score >= GRADE_THRESHOLDS.D) return 'D'
+  return 'F'
+}
+
+/**
+ * Generate human-readable description based on score and metrics
+ */
+function generateDescription(
+  grade: QualityGrade,
+  _overallScore: number,
+  _audioScore: number,
+  _videoScore: number | null,
+  networkScore: number,
+  input: QualityScoreInput
+): string {
+  switch (grade) {
+    case 'A':
+      return 'Excellent call quality'
+    case 'B':
+      return 'Good call quality'
+    case 'C': {
+      const issues: string[] = []
+      if (networkScore < 65) issues.push('network latency')
+      if (input.packetLoss && input.packetLoss > 2) issues.push('packet loss')
+      if (input.jitter && input.jitter > 40) issues.push('jitter')
+      if (issues.length > 0) {
+        return `Fair call quality - ${issues.join(', ')} detected`
+      }
+      return 'Fair call quality'
+    }
+    case 'D': {
+      const issues: string[] = []
+      if (networkScore < 50) issues.push('high network delay')
+      if (input.packetLoss && input.packetLoss > 5) issues.push('significant packet loss')
+      if (input.jitter && input.jitter > 80) issues.push('high jitter')
+      if (issues.length > 0) {
+        return `Poor call quality - ${issues.join(', ')}`
+      }
+      return 'Poor call quality'
+    }
+    case 'F': {
+      const issues: string[] = []
+      if (networkScore < 40) issues.push('severe network issues')
+      if (input.packetLoss && input.packetLoss > 10) issues.push('critical packet loss')
+      if (issues.length > 0) {
+        return `Very poor call quality - ${issues.join(', ')}`
+      }
+      return 'Very poor call quality - consider reconnecting'
+    }
+  }
+}
+
+/**
+ * Calculate trend direction and rate from history
+ */
+function calculateTrend(history: CallQualityScore[]): QualityTrend | null {
+  if (history.length < MIN_TREND_ENTRIES) {
+    // Not enough data, return low confidence trend if we have at least 2 entries
+    if (history.length >= 2) {
+      const first = history[0]!.overall
+      const last = history[history.length - 1]!.overall
+      const rate = (last - first) / (history.length - 1)
+
+      let direction: QualityTrendDirection
+      if (rate > TREND_STABILITY_THRESHOLD) {
+        direction = 'improving'
+      } else if (rate < -TREND_STABILITY_THRESHOLD) {
+        direction = 'degrading'
+      } else {
+        direction = 'stable'
+      }
+
+      return {
+        direction,
+        rate,
+        confidence: 0.3, // Low confidence with insufficient data
+      }
+    }
+    return null
+  }
+
+  // Calculate linear regression for trend
+  const n = history.length
+  let sumX = 0
+  let sumY = 0
+  let sumXY = 0
+  let sumX2 = 0
+
+  for (let i = 0; i < n; i++) {
+    const entry = history[i]!
+    sumX += i
+    sumY += entry.overall
+    sumXY += i * entry.overall
+    sumX2 += i * i
+  }
+
+  const slope = (n * sumXY - sumX * sumY) / (n * sumX2 - sumX * sumX)
+  const meanY = sumY / n
+
+  // Calculate R-squared for confidence
+  let ssRes = 0
+  let ssTot = 0
+  for (let i = 0; i < n; i++) {
+    const entry = history[i]!
+    const predicted = sumY / n + slope * (i - (n - 1) / 2)
+    ssRes += Math.pow(entry.overall - predicted, 2)
+    ssTot += Math.pow(entry.overall - meanY, 2)
+  }
+
+  const rSquared = ssTot > 0 ? 1 - ssRes / ssTot : 0
+  const confidence = clamp(rSquared * (n / 10), 0, 1) // Scale confidence by sample size
+
+  let direction: QualityTrendDirection
+  if (slope > TREND_STABILITY_THRESHOLD) {
+    direction = 'improving'
+  } else if (slope < -TREND_STABILITY_THRESHOLD) {
+    direction = 'degrading'
+  } else {
+    direction = 'stable'
+  }
+
+  return {
+    direction,
+    rate: slope,
+    confidence,
+  }
+}
+
+// =============================================================================
+// Main Composable
+// =============================================================================
+
+/**
+ * Composable for calculating comprehensive call quality scores
+ *
+ * @param options - Configuration options
+ * @returns Quality scoring interface
+ *
+ * @example
+ * ```ts
+ * const { score, trend, updateScore, reset } = useCallQualityScore({
+ *   weights: { packetLoss: 0.3 },
+ *   historySize: 20,
+ * })
+ *
+ * // Update with new stats
+ * updateScore({
+ *   packetLoss: 0.5,
+ *   jitter: 15,
+ *   rtt: 50,
+ *   mos: 4.2,
+ * })
+ *
+ * // Check current score
+ * console.log(score.value?.overall) // e.g., 85
+ * console.log(score.value?.grade) // e.g., 'B'
+ * ```
+ */
+export function useCallQualityScore(
+  options: CallQualityScoreOptions = {}
+): UseCallQualityScoreReturn {
+  const { weights: customWeights, historySize = 10, enableTrendAnalysis = true } = options
+
+  // Merge custom weights with defaults
+  const weights: Ref<QualityScoreWeights> = ref({
+    ...DEFAULT_QUALITY_WEIGHTS,
+    ...customWeights,
+  })
+
+  // State
+  const score: Ref<CallQualityScore | null> = ref(null)
+  const trend: Ref<QualityTrend | null> = ref(null)
+  const history: Ref<CallQualityScore[]> = ref([])
+  const lastInput: Ref<QualityScoreInput | null> = ref(null)
+
+  /**
+   * Calculate audio quality score
+   */
+  function calculateAudioScore(input: QualityScoreInput): number {
+    const mosScore = calculateMosScore(input.mos)
+    const packetLossScore = calculateMetricScore(
+      input.audioPacketLoss ?? input.packetLoss,
+      METRIC_THRESHOLDS.packetLoss
+    )
+    const jitterScore = calculateMetricScore(
+      input.audioJitterBufferDelay ?? input.jitter,
+      METRIC_THRESHOLDS.audioJitterBufferDelay
+    )
+
+    // Weighted combination for audio
+    return mosScore * 0.5 + packetLossScore * 0.3 + jitterScore * 0.2
+  }
+
+  /**
+   * Calculate video quality score
+   */
+  function calculateVideoScore(input: QualityScoreInput): number | null {
+    if (input.audioOnly) {
+      return null
+    }
+
+    // Check if we have any video metrics
+    const hasVideoMetrics =
+      input.videoPacketLoss !== undefined ||
+      input.framerate !== undefined ||
+      input.resolutionWidth !== undefined ||
+      input.freezeCount !== undefined
+
+    if (!hasVideoMetrics) {
+      return null
+    }
+
+    const packetLossScore = calculateMetricScore(
+      input.videoPacketLoss,
+      METRIC_THRESHOLDS.packetLoss,
+      80
+    )
+    const framerateScore = calculateFramerateScore(input.framerate, input.targetFramerate)
+    const resolutionScore = calculateResolutionScore(input.resolutionWidth, input.resolutionHeight)
+    const freezeScore = calculateFreezeScore(input.freezeCount)
+
+    // Weighted combination for video
+    return (
+      packetLossScore * 0.25 + framerateScore * 0.35 + resolutionScore * 0.25 + freezeScore * 0.15
+    )
+  }
+
+  /**
+   * Calculate network quality score
+   */
+  function calculateNetworkScore(input: QualityScoreInput): number {
+    const rttScore = calculateMetricScore(input.rtt, METRIC_THRESHOLDS.rtt)
+    const jitterScore = calculateMetricScore(input.jitter, METRIC_THRESHOLDS.jitter)
+    const packetLossScore = calculateMetricScore(input.packetLoss, METRIC_THRESHOLDS.packetLoss)
+
+    // RTT has highest impact on network score
+    return rttScore * 0.45 + jitterScore * 0.3 + packetLossScore * 0.25
+  }
+
+  /**
+   * Calculate overall quality score
+   */
+  function calculateOverallScore(input: QualityScoreInput): number {
+    const w = weights.value
+
+    const packetLossScore = calculateMetricScore(input.packetLoss, METRIC_THRESHOLDS.packetLoss)
+    const jitterScore = calculateMetricScore(input.jitter, METRIC_THRESHOLDS.jitter)
+    const rttScore = calculateMetricScore(input.rtt, METRIC_THRESHOLDS.rtt)
+    const mosScore = calculateMosScore(input.mos)
+    const bitrateScore = calculateBitrateStabilityScore(input.bitrate, input.previousBitrate)
+
+    return (
+      packetLossScore * w.packetLoss +
+      jitterScore * w.jitter +
+      rttScore * w.rtt +
+      mosScore * w.mos +
+      bitrateScore * w.bitrateStability
+    )
+  }
+
+  /**
+   * Update score with new stats
+   */
+  function updateScore(input: QualityScoreInput): void {
+    lastInput.value = input
+
+    const overallScore = calculateOverallScore(input)
+    const audioScore = calculateAudioScore(input)
+    const videoScore = calculateVideoScore(input)
+    const networkScore = calculateNetworkScore(input)
+    const grade = getGrade(overallScore)
+
+    const newScore: CallQualityScore = {
+      overall: Math.round(overallScore * 100) / 100,
+      audio: Math.round(audioScore * 100) / 100,
+      video: videoScore !== null ? Math.round(videoScore * 100) / 100 : null,
+      network: Math.round(networkScore * 100) / 100,
+      grade,
+      description: generateDescription(
+        grade,
+        overallScore,
+        audioScore,
+        videoScore,
+        networkScore,
+        input
+      ),
+      timestamp: Date.now(),
+    }
+
+    score.value = newScore
+
+    // Add to history
+    history.value = [...history.value, newScore].slice(-historySize)
+
+    // Update trend if enabled
+    if (enableTrendAnalysis) {
+      trend.value = calculateTrend(history.value)
+    }
+  }
+
+  /**
+   * Reset state
+   */
+  function reset(): void {
+    score.value = null
+    trend.value = null
+    history.value = []
+    lastInput.value = null
+  }
+
+  return {
+    score,
+    trend,
+    history,
+    updateScore,
+    reset,
+    weights,
+  }
+}

--- a/src/composables/useNetworkQualityIndicator.ts
+++ b/src/composables/useNetworkQualityIndicator.ts
@@ -1,0 +1,310 @@
+/**
+ * useNetworkQualityIndicator Composable
+ *
+ * Provides reactive network quality indicators for WebRTC connections
+ * including signal bars, quality levels, colors, and accessibility labels.
+ *
+ * @example
+ * ```typescript
+ * const { indicator, isAvailable, update, reset } = useNetworkQualityIndicator()
+ *
+ * // Update with WebRTC stats
+ * update({
+ *   rtt: 50,
+ *   jitter: 10,
+ *   packetLoss: 0.5,
+ *   candidateType: 'host'
+ * })
+ *
+ * // Use in template
+ * // <NetworkIndicator
+ * //   :bars="indicator.bars"
+ * //   :color="indicator.color"
+ * //   :aria-label="indicator.ariaLabel"
+ * // />
+ * ```
+ *
+ * @packageDocumentation
+ */
+
+import { ref, computed, type Ref } from 'vue'
+import {
+  type NetworkQualityLevel,
+  type SignalBars,
+  type NetworkQualityIcon,
+  type NetworkDetails,
+  type NetworkQualityIndicatorData,
+  type NetworkQualityColors,
+  type NetworkQualityThresholds,
+  type NetworkQualityIndicatorOptions,
+  type NetworkQualityInput,
+  type UseNetworkQualityIndicatorReturn,
+  DEFAULT_NETWORK_COLORS,
+  DEFAULT_NETWORK_THRESHOLDS,
+} from '@/types/call-quality.types'
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/**
+ * Mapping from quality level to signal bars (1-5)
+ */
+const LEVEL_TO_BARS: Record<NetworkQualityLevel, SignalBars> = {
+  excellent: 5,
+  good: 4,
+  fair: 3,
+  poor: 2,
+  critical: 1,
+  unknown: 1,
+}
+
+/**
+ * Mapping from quality level to icon name
+ */
+const LEVEL_TO_ICON: Record<NetworkQualityLevel, NetworkQualityIcon> = {
+  excellent: 'signal-excellent',
+  good: 'signal-good',
+  fair: 'signal-fair',
+  poor: 'signal-poor',
+  critical: 'signal-critical',
+  unknown: 'signal-unknown',
+}
+
+/**
+ * Aria label templates for each quality level
+ */
+const LEVEL_TO_ARIA: Record<NetworkQualityLevel, string> = {
+  excellent: 'Network quality: excellent connection',
+  good: 'Network quality: good connection',
+  fair: 'Network quality: fair connection',
+  poor: 'Network quality: poor connection',
+  critical: 'Network quality: critical - connection issues',
+  unknown: 'Network quality: unavailable - no data',
+}
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+/**
+ * Clamp a value to be at least 0
+ */
+function clampNonNegative(value: number): number {
+  return Math.max(0, value)
+}
+
+/**
+ * Determine quality level for a single metric based on thresholds
+ * Thresholds are [excellent, good, fair, poor] - values above poor are critical
+ */
+function getMetricLevel(
+  value: number,
+  thresholds: [number, number, number, number]
+): NetworkQualityLevel {
+  const normalizedValue = clampNonNegative(value)
+  const [excellent, good, fair, poor] = thresholds
+
+  if (normalizedValue <= excellent) return 'excellent'
+  if (normalizedValue <= good) return 'good'
+  if (normalizedValue <= fair) return 'fair'
+  if (normalizedValue <= poor) return 'poor'
+  return 'critical'
+}
+
+/**
+ * Get the worst quality level from multiple levels
+ * Order: critical < poor < fair < good < excellent
+ */
+function getWorstLevel(levels: NetworkQualityLevel[]): NetworkQualityLevel {
+  const priority: Record<NetworkQualityLevel, number> = {
+    critical: 0,
+    poor: 1,
+    fair: 2,
+    good: 3,
+    excellent: 4,
+    unknown: -1, // Should not be used in comparison
+  }
+
+  let worst: NetworkQualityLevel = 'excellent'
+  let worstPriority = priority.excellent
+
+  for (const level of levels) {
+    if (level !== 'unknown' && priority[level] < worstPriority) {
+      worst = level
+      worstPriority = priority[level]
+    }
+  }
+
+  return worst
+}
+
+/**
+ * Create default network details
+ */
+function createDefaultDetails(): NetworkDetails {
+  return {
+    rtt: 0,
+    jitter: 0,
+    packetLoss: 0,
+    bandwidth: 0,
+    connectionType: 'unknown',
+  }
+}
+
+/**
+ * Create default indicator data
+ * @internal Used for potential future reset functionality
+ */
+function _createDefaultIndicator(colors: NetworkQualityColors): NetworkQualityIndicatorData {
+  return {
+    level: 'unknown',
+    bars: 1,
+    color: colors.unknown,
+    icon: 'signal-unknown',
+    ariaLabel: LEVEL_TO_ARIA.unknown,
+    details: createDefaultDetails(),
+  }
+}
+void _createDefaultIndicator // Suppress unused warning
+
+// =============================================================================
+// Main Composable
+// =============================================================================
+
+/**
+ * Network quality indicator composable
+ *
+ * @param options - Configuration options
+ * @returns Reactive network quality indicator state and controls
+ */
+export function useNetworkQualityIndicator(
+  options: NetworkQualityIndicatorOptions = {}
+): UseNetworkQualityIndicatorReturn {
+  // Merge options with defaults
+  const colors: NetworkQualityColors = {
+    ...DEFAULT_NETWORK_COLORS,
+    ...options.colors,
+  }
+
+  const thresholds: NetworkQualityThresholds = {
+    rtt: options.thresholds?.rtt ?? DEFAULT_NETWORK_THRESHOLDS.rtt,
+    packetLoss: options.thresholds?.packetLoss ?? DEFAULT_NETWORK_THRESHOLDS.packetLoss,
+    jitter: options.thresholds?.jitter ?? DEFAULT_NETWORK_THRESHOLDS.jitter,
+  }
+
+  const estimateBandwidth = options.estimateBandwidth !== false // Default true
+
+  // State
+  const isAvailable: Ref<boolean> = ref(false)
+  const currentDetails: Ref<NetworkDetails> = ref(createDefaultDetails())
+  const currentLevel: Ref<NetworkQualityLevel> = ref('unknown')
+
+  // Computed indicator data
+  const indicator = computed<NetworkQualityIndicatorData>(() => {
+    const level = currentLevel.value
+    return {
+      level,
+      bars: LEVEL_TO_BARS[level],
+      color: colors[level],
+      icon: LEVEL_TO_ICON[level],
+      ariaLabel: LEVEL_TO_ARIA[level],
+      details: { ...currentDetails.value },
+    }
+  })
+
+  /**
+   * Calculate the overall quality level from input metrics
+   */
+  function calculateLevel(input: NetworkQualityInput): NetworkQualityLevel {
+    const levels: NetworkQualityLevel[] = []
+
+    // Check each available metric
+    if (input.rtt !== undefined) {
+      levels.push(getMetricLevel(input.rtt, thresholds.rtt))
+    }
+
+    if (input.jitter !== undefined) {
+      levels.push(getMetricLevel(input.jitter, thresholds.jitter))
+    }
+
+    if (input.packetLoss !== undefined) {
+      levels.push(getMetricLevel(input.packetLoss, thresholds.packetLoss))
+    }
+
+    // If no metrics provided, return unknown
+    if (levels.length === 0) {
+      return 'unknown'
+    }
+
+    // Return the worst level among all metrics
+    return getWorstLevel(levels)
+  }
+
+  /**
+   * Update details from input, preserving previous values for undefined metrics
+   */
+  function updateDetails(input: NetworkQualityInput): void {
+    const details = currentDetails.value
+
+    if (input.rtt !== undefined) {
+      details.rtt = clampNonNegative(input.rtt)
+    }
+
+    if (input.jitter !== undefined) {
+      details.jitter = clampNonNegative(input.jitter)
+    }
+
+    if (input.packetLoss !== undefined) {
+      details.packetLoss = clampNonNegative(input.packetLoss)
+    }
+
+    if (input.candidateType !== undefined) {
+      details.connectionType = input.candidateType
+    }
+
+    // Handle bandwidth
+    if (input.availableOutgoingBitrate !== undefined) {
+      details.bandwidth = input.availableOutgoingBitrate
+    } else if (estimateBandwidth && input.bitrate !== undefined) {
+      // Estimate bandwidth from current bitrate
+      // Use a simple heuristic: available bandwidth is roughly 1.2x current usage
+      details.bandwidth = Math.round(input.bitrate * 1.2)
+    }
+  }
+
+  /**
+   * Update indicator with new network statistics
+   */
+  function update(input: NetworkQualityInput): void {
+    // Calculate new level
+    const newLevel = calculateLevel(input)
+
+    // If we got any valid metrics, mark as available
+    if (newLevel !== 'unknown') {
+      isAvailable.value = true
+    }
+
+    // Update details
+    updateDetails(input)
+
+    // Update level (triggers computed recalculation)
+    currentLevel.value = newLevel
+  }
+
+  /**
+   * Reset indicator to unknown state
+   */
+  function reset(): void {
+    isAvailable.value = false
+    currentLevel.value = 'unknown'
+    currentDetails.value = createDefaultDetails()
+  }
+
+  return {
+    indicator,
+    isAvailable,
+    update,
+    reset,
+  }
+}

--- a/src/types/call-quality.types.ts
+++ b/src/types/call-quality.types.ts
@@ -1,0 +1,462 @@
+/**
+ * Call Quality Types
+ *
+ * Type definitions for comprehensive call quality scoring,
+ * network quality indicators, and bandwidth adaptation.
+ *
+ * @packageDocumentation
+ */
+
+// =============================================================================
+// Quality Score Types
+// =============================================================================
+
+/**
+ * Quality grade assignment based on overall score
+ */
+export type QualityGrade = 'A' | 'B' | 'C' | 'D' | 'F'
+
+/**
+ * Comprehensive call quality score combining multiple metrics
+ */
+export interface CallQualityScore {
+  /** Overall score 0-100 */
+  overall: number
+  /** Audio quality score 0-100 */
+  audio: number
+  /** Video quality score 0-100 (null if audio-only) */
+  video: number | null
+  /** Network stability score 0-100 */
+  network: number
+  /** Quality grade */
+  grade: QualityGrade
+  /** Human-readable quality description */
+  description: string
+  /** Timestamp of score calculation */
+  timestamp: number
+}
+
+/**
+ * Quality score weights for different metrics
+ * All weights should sum to 1.0
+ */
+export interface QualityScoreWeights {
+  /** Weight for packet loss impact (0-1) */
+  packetLoss: number
+  /** Weight for jitter impact (0-1) */
+  jitter: number
+  /** Weight for round-trip time impact (0-1) */
+  rtt: number
+  /** Weight for MOS score impact (0-1) */
+  mos: number
+  /** Weight for bitrate stability impact (0-1) */
+  bitrateStability: number
+}
+
+/**
+ * Default quality score weights
+ */
+export const DEFAULT_QUALITY_WEIGHTS: QualityScoreWeights = {
+  packetLoss: 0.25,
+  jitter: 0.15,
+  rtt: 0.2,
+  mos: 0.25,
+  bitrateStability: 0.15,
+}
+
+/**
+ * Quality trend direction
+ */
+export type QualityTrendDirection = 'improving' | 'stable' | 'degrading'
+
+/**
+ * Quality trend over time
+ */
+export interface QualityTrend {
+  /** Direction of quality change */
+  direction: QualityTrendDirection
+  /** Rate of change (-100 to 100, negative = degrading) */
+  rate: number
+  /** Confidence in trend (0-1, higher = more certain) */
+  confidence: number
+}
+
+/**
+ * Options for useCallQualityScore composable
+ */
+export interface CallQualityScoreOptions {
+  /** Custom weight configuration (partial, will be merged with defaults) */
+  weights?: Partial<QualityScoreWeights>
+  /** History size for trend calculation @default 10 */
+  historySize?: number
+  /** Update interval in ms @default 1000 */
+  updateInterval?: number
+  /** Enable trend analysis @default true */
+  enableTrendAnalysis?: boolean
+}
+
+/**
+ * Input stats for quality score calculation
+ */
+export interface QualityScoreInput {
+  /** Packet loss percentage (0-100) */
+  packetLoss?: number
+  /** Jitter in milliseconds */
+  jitter?: number
+  /** Round-trip time in milliseconds */
+  rtt?: number
+  /** MOS score (1-5) */
+  mos?: number
+  /** Current bitrate in kbps */
+  bitrate?: number
+  /** Previous bitrate for stability calculation */
+  previousBitrate?: number
+  /** Audio-specific packet loss */
+  audioPacketLoss?: number
+  /** Audio jitter buffer delay in ms */
+  audioJitterBufferDelay?: number
+  /** Video packet loss */
+  videoPacketLoss?: number
+  /** Video framerate */
+  framerate?: number
+  /** Target framerate */
+  targetFramerate?: number
+  /** Video resolution width */
+  resolutionWidth?: number
+  /** Video resolution height */
+  resolutionHeight?: number
+  /** Number of freeze events */
+  freezeCount?: number
+  /** Whether this is an audio-only call */
+  audioOnly?: boolean
+}
+
+/**
+ * Return type for useCallQualityScore composable
+ */
+export interface UseCallQualityScoreReturn {
+  /** Current quality score (null if no stats available) */
+  score: import('vue').Ref<CallQualityScore | null>
+  /** Quality trend (null if insufficient history) */
+  trend: import('vue').Ref<QualityTrend | null>
+  /** Score history for charting */
+  history: import('vue').Ref<CallQualityScore[]>
+  /** Update score with new stats */
+  updateScore: (input: QualityScoreInput) => void
+  /** Clear history and reset */
+  reset: () => void
+  /** Current weights being used */
+  weights: import('vue').Ref<QualityScoreWeights>
+}
+
+// =============================================================================
+// Network Quality Indicator Types
+// =============================================================================
+
+/**
+ * Network quality level for visual indicators
+ */
+export type NetworkQualityLevel = 'excellent' | 'good' | 'fair' | 'poor' | 'critical' | 'unknown'
+
+/**
+ * Signal bar count (1-5)
+ */
+export type SignalBars = 1 | 2 | 3 | 4 | 5
+
+/**
+ * Icon name for network quality
+ */
+export type NetworkQualityIcon =
+  | 'signal-excellent'
+  | 'signal-good'
+  | 'signal-fair'
+  | 'signal-poor'
+  | 'signal-critical'
+  | 'signal-unknown'
+
+/**
+ * Detailed network metrics for tooltip display
+ */
+export interface NetworkDetails {
+  /** Round-trip time in ms */
+  rtt: number
+  /** Jitter in ms */
+  jitter: number
+  /** Packet loss percentage (0-100) */
+  packetLoss: number
+  /** Available bandwidth estimate in kbps */
+  bandwidth: number
+  /** Connection type (relay/srflx/host/prflx) */
+  connectionType: string
+}
+
+/**
+ * Network quality indicator data for UI
+ */
+export interface NetworkQualityIndicatorData {
+  /** Current quality level */
+  level: NetworkQualityLevel
+  /** Signal strength bars (1-5) */
+  bars: SignalBars
+  /** Color for UI (CSS color value) */
+  color: string
+  /** Icon name suggestion */
+  icon: NetworkQualityIcon
+  /** Accessibility label */
+  ariaLabel: string
+  /** Detailed metrics for tooltip */
+  details: NetworkDetails
+}
+
+/**
+ * Color scheme for network quality levels
+ */
+export type NetworkQualityColors = Record<NetworkQualityLevel, string>
+
+/**
+ * Default colors for network quality levels
+ */
+export const DEFAULT_NETWORK_COLORS: NetworkQualityColors = {
+  excellent: '#22c55e', // green-500
+  good: '#22c55e', // green-500
+  fair: '#eab308', // yellow-500
+  poor: '#f97316', // orange-500
+  critical: '#ef4444', // red-500
+  unknown: '#9ca3af', // gray-400
+}
+
+/**
+ * Thresholds for network quality level determination
+ */
+export interface NetworkQualityThresholds {
+  /** RTT thresholds in ms [excellent, good, fair, poor] */
+  rtt: [number, number, number, number]
+  /** Packet loss thresholds in % [excellent, good, fair, poor] */
+  packetLoss: [number, number, number, number]
+  /** Jitter thresholds in ms [excellent, good, fair, poor] */
+  jitter: [number, number, number, number]
+}
+
+/**
+ * Default network quality thresholds
+ */
+export const DEFAULT_NETWORK_THRESHOLDS: NetworkQualityThresholds = {
+  rtt: [50, 100, 200, 400],
+  packetLoss: [0.5, 1, 2, 5],
+  jitter: [10, 20, 40, 80],
+}
+
+/**
+ * Options for useNetworkQualityIndicator composable
+ */
+export interface NetworkQualityIndicatorOptions {
+  /** Update interval in ms @default 1000 */
+  updateInterval?: number
+  /** Custom color scheme */
+  colors?: Partial<NetworkQualityColors>
+  /** Enable bandwidth estimation @default true */
+  estimateBandwidth?: boolean
+  /** Custom thresholds */
+  thresholds?: Partial<NetworkQualityThresholds>
+}
+
+/**
+ * Input for network quality indicator
+ */
+export interface NetworkQualityInput {
+  /** Round-trip time in ms */
+  rtt?: number
+  /** Jitter in ms */
+  jitter?: number
+  /** Packet loss percentage (0-100) */
+  packetLoss?: number
+  /** Current bitrate in kbps (for bandwidth estimation) */
+  bitrate?: number
+  /** Available outgoing bitrate from BWE */
+  availableOutgoingBitrate?: number
+  /** ICE candidate pair type */
+  candidateType?: string
+}
+
+/**
+ * Return type for useNetworkQualityIndicator composable
+ */
+export interface UseNetworkQualityIndicatorReturn {
+  /** Current indicator data */
+  indicator: import('vue').Ref<NetworkQualityIndicatorData>
+  /** Whether data is available */
+  isAvailable: import('vue').Ref<boolean>
+  /** Update indicator with new stats */
+  update: (input: NetworkQualityInput) => void
+  /** Reset to unknown state */
+  reset: () => void
+}
+
+// =============================================================================
+// Bandwidth Adaptation Types
+// =============================================================================
+
+/**
+ * Bandwidth adaptation action
+ */
+export type BandwidthAction = 'upgrade' | 'maintain' | 'downgrade' | 'critical'
+
+/**
+ * Priority level for recommendations
+ */
+export type RecommendationPriority = 'low' | 'medium' | 'high' | 'critical'
+
+/**
+ * Suggestion type for bandwidth adaptation
+ */
+export type SuggestionType = 'video' | 'audio' | 'network' | 'codec'
+
+/**
+ * Specific adaptation suggestion
+ */
+export interface AdaptationSuggestion {
+  /** Type of suggestion */
+  type: SuggestionType
+  /** Suggestion text for display */
+  message: string
+  /** Current value description */
+  current: string
+  /** Recommended value description */
+  recommended: string
+  /** Impact on quality improvement (0-100) */
+  impact: number
+}
+
+/**
+ * Bandwidth adaptation recommendation
+ */
+export interface BandwidthRecommendation {
+  /** Recommended action */
+  action: BandwidthAction
+  /** Specific recommendations ordered by impact */
+  suggestions: AdaptationSuggestion[]
+  /** Priority level */
+  priority: RecommendationPriority
+  /** Estimated quality improvement if applied (0-100) */
+  estimatedImprovement: number
+  /** Timestamp of recommendation */
+  timestamp: number
+}
+
+/**
+ * Video resolution preset
+ */
+export interface VideoResolution {
+  width: number
+  height: number
+  label: string
+}
+
+/**
+ * Standard video resolutions
+ */
+export const VIDEO_RESOLUTIONS: VideoResolution[] = [
+  { width: 1920, height: 1080, label: '1080p' },
+  { width: 1280, height: 720, label: '720p' },
+  { width: 854, height: 480, label: '480p' },
+  { width: 640, height: 360, label: '360p' },
+  { width: 426, height: 240, label: '240p' },
+]
+
+/**
+ * Bandwidth adaptation constraints
+ */
+export interface BandwidthConstraints {
+  /** Minimum acceptable video bitrate in kbps @default 100 */
+  minVideoBitrate?: number
+  /** Maximum video bitrate in kbps @default 2500 */
+  maxVideoBitrate?: number
+  /** Minimum audio bitrate in kbps @default 16 */
+  minAudioBitrate?: number
+  /** Maximum audio bitrate in kbps @default 128 */
+  maxAudioBitrate?: number
+  /** Target framerate @default 30 */
+  targetFramerate?: number
+  /** Minimum acceptable framerate @default 15 */
+  minFramerate?: number
+  /** Minimum acceptable resolution */
+  minResolution?: VideoResolution
+  /** Preferred resolution */
+  preferredResolution?: VideoResolution
+}
+
+/**
+ * Default bandwidth constraints
+ */
+export const DEFAULT_BANDWIDTH_CONSTRAINTS: Required<BandwidthConstraints> = {
+  minVideoBitrate: 100,
+  maxVideoBitrate: 2500,
+  minAudioBitrate: 16,
+  maxAudioBitrate: 128,
+  targetFramerate: 30,
+  minFramerate: 15,
+  minResolution: { width: 426, height: 240, label: '240p' },
+  preferredResolution: { width: 1280, height: 720, label: '720p' },
+}
+
+/**
+ * Options for useBandwidthAdaptation composable
+ */
+export interface BandwidthAdaptationOptions {
+  /** Constraints for adaptation */
+  constraints?: BandwidthConstraints
+  /** Adaptation sensitivity (0-1, higher = more reactive) @default 0.5 */
+  sensitivity?: number
+  /** Enable automatic adaptation (vs recommendation only) @default false */
+  autoAdapt?: boolean
+  /** Callback when recommendation changes */
+  onRecommendation?: (rec: BandwidthRecommendation) => void
+  /** History size for smoothing @default 5 */
+  historySize?: number
+}
+
+/**
+ * Input for bandwidth adaptation
+ */
+export interface BandwidthAdaptationInput {
+  /** Available outgoing bitrate in kbps */
+  availableBitrate?: number
+  /** Current send bitrate in kbps */
+  currentBitrate?: number
+  /** Packet loss percentage */
+  packetLoss?: number
+  /** Round-trip time in ms */
+  rtt?: number
+  /** Current video resolution */
+  currentResolution?: VideoResolution
+  /** Current framerate */
+  currentFramerate?: number
+  /** Current audio bitrate */
+  currentAudioBitrate?: number
+  /** Whether video is enabled */
+  videoEnabled?: boolean
+  /** Number of recent quality degradation events */
+  degradationEvents?: number
+}
+
+/**
+ * Return type for useBandwidthAdaptation composable
+ */
+export interface UseBandwidthAdaptationReturn {
+  /** Current recommendation */
+  recommendation: import('vue').Ref<BandwidthRecommendation>
+  /** Whether auto-adaptation is enabled */
+  isAutoAdapting: import('vue').Ref<boolean>
+  /** Current constraints */
+  constraints: import('vue').Ref<Required<BandwidthConstraints>>
+  /** Update with new stats */
+  update: (input: BandwidthAdaptationInput) => void
+  /** Enable/disable auto-adaptation */
+  setAutoAdapt: (enabled: boolean) => void
+  /** Update constraints */
+  setConstraints: (constraints: Partial<BandwidthConstraints>) => void
+  /** Reset to defaults */
+  reset: () => void
+  /** Apply a specific suggestion manually */
+  applySuggestion: (suggestion: AdaptationSuggestion) => void
+}

--- a/tests/unit/composables/useBandwidthAdaptation.test.ts
+++ b/tests/unit/composables/useBandwidthAdaptation.test.ts
@@ -1,0 +1,844 @@
+/**
+ * Tests for useBandwidthAdaptation composable
+ *
+ * TDD specifications for bandwidth adaptation functionality
+ * including recommendations, suggestions, auto-adaptation, and constraints.
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { useBandwidthAdaptation } from '@/composables/useBandwidthAdaptation'
+import {
+  DEFAULT_BANDWIDTH_CONSTRAINTS,
+  VIDEO_RESOLUTIONS,
+  type RecommendationPriority,
+  type AdaptationSuggestion,
+} from '@/types/call-quality.types'
+
+describe('useBandwidthAdaptation', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  // ==========================================================================
+  // Initialization and Default State
+  // ==========================================================================
+
+  describe('Initialization', () => {
+    it('should initialize with maintain action and no suggestions', () => {
+      const { recommendation } = useBandwidthAdaptation()
+
+      expect(recommendation.value.action).toBe('maintain')
+      expect(recommendation.value.suggestions).toEqual([])
+      expect(recommendation.value.priority).toBe('low')
+      expect(recommendation.value.estimatedImprovement).toBe(0)
+    })
+
+    it('should initialize with default constraints', () => {
+      const { constraints } = useBandwidthAdaptation()
+
+      expect(constraints.value).toEqual(DEFAULT_BANDWIDTH_CONSTRAINTS)
+    })
+
+    it('should initialize with auto-adaptation disabled by default', () => {
+      const { isAutoAdapting } = useBandwidthAdaptation()
+
+      expect(isAutoAdapting.value).toBe(false)
+    })
+
+    it('should accept custom constraints', () => {
+      const { constraints } = useBandwidthAdaptation({
+        constraints: {
+          minVideoBitrate: 200,
+          maxVideoBitrate: 5000,
+        },
+      })
+
+      expect(constraints.value.minVideoBitrate).toBe(200)
+      expect(constraints.value.maxVideoBitrate).toBe(5000)
+      // Other constraints should use defaults
+      expect(constraints.value.minAudioBitrate).toBe(DEFAULT_BANDWIDTH_CONSTRAINTS.minAudioBitrate)
+    })
+
+    it('should accept custom sensitivity', () => {
+      const { recommendation, update } = useBandwidthAdaptation({
+        sensitivity: 0.9, // High sensitivity
+      })
+
+      // With high sensitivity, moderately poor conditions should trigger downgrade
+      update({
+        availableBitrate: 600,
+        currentBitrate: 1000,
+        packetLoss: 3,
+        rtt: 200,
+      })
+
+      // High sensitivity should be more reactive to moderate conditions
+      expect(recommendation.value.action).not.toBe('maintain')
+    })
+
+    it('should enable auto-adaptation when option is true', () => {
+      const { isAutoAdapting } = useBandwidthAdaptation({
+        autoAdapt: true,
+      })
+
+      expect(isAutoAdapting.value).toBe(true)
+    })
+  })
+
+  // ==========================================================================
+  // Recommendation Actions
+  // ==========================================================================
+
+  describe('Recommendation Actions', () => {
+    describe('Upgrade Action', () => {
+      it('should recommend upgrade when bandwidth is abundant', () => {
+        const { recommendation, update } = useBandwidthAdaptation()
+
+        update({
+          availableBitrate: 5000,
+          currentBitrate: 1000,
+          packetLoss: 0,
+          rtt: 20,
+          currentResolution: VIDEO_RESOLUTIONS[2], // 480p
+          currentFramerate: 30,
+        })
+
+        expect(recommendation.value.action).toBe('upgrade')
+      })
+
+      it('should suggest resolution upgrade when bandwidth allows', () => {
+        const { recommendation, update } = useBandwidthAdaptation()
+
+        update({
+          availableBitrate: 4000,
+          currentBitrate: 1500,
+          packetLoss: 0,
+          rtt: 30,
+          currentResolution: VIDEO_RESOLUTIONS[2], // 480p
+          videoEnabled: true,
+        })
+
+        const videoSuggestion = recommendation.value.suggestions.find((s) => s.type === 'video')
+        expect(videoSuggestion).toBeDefined()
+        expect(videoSuggestion?.message).toMatch(/resolution|quality/i)
+      })
+    })
+
+    describe('Maintain Action', () => {
+      it('should recommend maintain when conditions are stable', () => {
+        const { recommendation, update } = useBandwidthAdaptation()
+
+        update({
+          availableBitrate: 2000,
+          currentBitrate: 1800,
+          packetLoss: 0.3,
+          rtt: 50,
+          currentResolution: VIDEO_RESOLUTIONS[1], // 720p
+          currentFramerate: 30,
+        })
+
+        expect(recommendation.value.action).toBe('maintain')
+      })
+
+      it('should have no suggestions when maintaining', () => {
+        const { recommendation, update } = useBandwidthAdaptation()
+
+        update({
+          availableBitrate: 2000,
+          currentBitrate: 1800,
+          packetLoss: 0.2,
+          rtt: 40,
+        })
+
+        // If maintaining, suggestions should be empty or low impact
+        if (recommendation.value.action === 'maintain') {
+          expect(recommendation.value.suggestions.length).toBe(0)
+        }
+      })
+    })
+
+    describe('Downgrade Action', () => {
+      it('should recommend downgrade when bandwidth is constrained', () => {
+        const { recommendation, update } = useBandwidthAdaptation()
+
+        update({
+          availableBitrate: 500,
+          currentBitrate: 1500,
+          packetLoss: 3,
+          rtt: 200,
+          currentResolution: VIDEO_RESOLUTIONS[1], // 720p
+        })
+
+        expect(recommendation.value.action).toBe('downgrade')
+      })
+
+      it('should suggest resolution downgrade when bandwidth is limited', () => {
+        const { recommendation, update } = useBandwidthAdaptation()
+
+        update({
+          availableBitrate: 400,
+          currentBitrate: 1200,
+          packetLoss: 2,
+          currentResolution: VIDEO_RESOLUTIONS[0], // 1080p
+          videoEnabled: true,
+        })
+
+        const videoSuggestion = recommendation.value.suggestions.find((s) => s.type === 'video')
+        expect(videoSuggestion).toBeDefined()
+      })
+
+      it('should suggest framerate reduction when needed', () => {
+        const { recommendation, update } = useBandwidthAdaptation()
+
+        update({
+          availableBitrate: 400,
+          currentBitrate: 1000,
+          packetLoss: 3,
+          rtt: 200,
+          currentFramerate: 30,
+          videoEnabled: true,
+        })
+
+        // Should suggest reducing framerate (since no resolution provided, framerate is the suggestion)
+        expect(recommendation.value.suggestions.length).toBeGreaterThan(0)
+      })
+    })
+
+    describe('Critical Action', () => {
+      it('should recommend critical when conditions are severe', () => {
+        const { recommendation, update } = useBandwidthAdaptation()
+
+        update({
+          availableBitrate: 100,
+          currentBitrate: 1500,
+          packetLoss: 10,
+          rtt: 500,
+          degradationEvents: 5,
+        })
+
+        expect(recommendation.value.action).toBe('critical')
+      })
+
+      it('should have high priority for critical recommendations', () => {
+        const { recommendation, update } = useBandwidthAdaptation()
+
+        update({
+          availableBitrate: 50,
+          currentBitrate: 1000,
+          packetLoss: 15,
+          rtt: 600,
+        })
+
+        expect(recommendation.value.priority).toBe('critical')
+      })
+
+      it('should suggest disabling video in critical conditions', () => {
+        const { recommendation, update } = useBandwidthAdaptation()
+
+        update({
+          availableBitrate: 50,
+          currentBitrate: 800,
+          packetLoss: 12,
+          videoEnabled: true,
+        })
+
+        const videoSuggestion = recommendation.value.suggestions.find((s) => s.type === 'video')
+        expect(videoSuggestion?.message).toMatch(/disable|turn off|audio.only/i)
+      })
+    })
+  })
+
+  // ==========================================================================
+  // Priority Levels
+  // ==========================================================================
+
+  describe('Priority Levels', () => {
+    it.each([
+      [{ availableBitrate: 3000, currentBitrate: 1000, packetLoss: 0 }, 'low'],
+      [{ availableBitrate: 800, currentBitrate: 1000, packetLoss: 2 }, 'medium'],
+      [{ availableBitrate: 400, currentBitrate: 1000, packetLoss: 4 }, 'high'],
+      [{ availableBitrate: 100, currentBitrate: 1000, packetLoss: 10 }, 'critical'],
+    ] as [Record<string, number>, RecommendationPriority][])(
+      'should assign %s priority for conditions',
+      (input, expectedPriority) => {
+        const { recommendation, update } = useBandwidthAdaptation()
+
+        update(input)
+
+        expect(recommendation.value.priority).toBe(expectedPriority)
+      }
+    )
+  })
+
+  // ==========================================================================
+  // Suggestions
+  // ==========================================================================
+
+  describe('Suggestions', () => {
+    it('should order suggestions by impact (highest first)', () => {
+      const { recommendation, update } = useBandwidthAdaptation()
+
+      update({
+        availableBitrate: 300,
+        currentBitrate: 1500,
+        packetLoss: 5,
+        currentResolution: VIDEO_RESOLUTIONS[0], // 1080p
+        currentFramerate: 30,
+        currentAudioBitrate: 128,
+        videoEnabled: true,
+      })
+
+      const suggestions = recommendation.value.suggestions
+      if (suggestions.length >= 2) {
+        for (let i = 1; i < suggestions.length; i++) {
+          expect(suggestions[i - 1].impact).toBeGreaterThanOrEqual(suggestions[i].impact)
+        }
+      }
+    })
+
+    it('should include current and recommended values in suggestions', () => {
+      const { recommendation, update } = useBandwidthAdaptation()
+
+      update({
+        availableBitrate: 300,
+        currentBitrate: 1500,
+        currentResolution: VIDEO_RESOLUTIONS[0], // 1080p
+        videoEnabled: true,
+      })
+
+      const suggestions = recommendation.value.suggestions
+      if (suggestions.length > 0) {
+        const suggestion = suggestions[0]
+        expect(suggestion.current).toBeTruthy()
+        expect(suggestion.recommended).toBeTruthy()
+        expect(suggestion.current).not.toBe(suggestion.recommended)
+      }
+    })
+
+    it('should include video suggestions when video is enabled', () => {
+      const { recommendation, update } = useBandwidthAdaptation()
+
+      update({
+        availableBitrate: 300,
+        currentBitrate: 1200,
+        currentResolution: VIDEO_RESOLUTIONS[0],
+        videoEnabled: true,
+      })
+
+      const videoSuggestions = recommendation.value.suggestions.filter((s) => s.type === 'video')
+      expect(videoSuggestions.length).toBeGreaterThan(0)
+    })
+
+    it('should not include video suggestions when video is disabled', () => {
+      const { recommendation, update } = useBandwidthAdaptation()
+
+      update({
+        availableBitrate: 300,
+        currentBitrate: 100,
+        videoEnabled: false,
+      })
+
+      const videoSuggestions = recommendation.value.suggestions.filter((s) => s.type === 'video')
+      expect(videoSuggestions.length).toBe(0)
+    })
+
+    it('should include audio suggestions when audio bitrate is high', () => {
+      const { recommendation, update } = useBandwidthAdaptation()
+
+      update({
+        availableBitrate: 50,
+        currentBitrate: 200,
+        currentAudioBitrate: 128,
+        videoEnabled: false,
+      })
+
+      const audioSuggestions = recommendation.value.suggestions.filter((s) => s.type === 'audio')
+      expect(audioSuggestions.length).toBeGreaterThan(0)
+    })
+  })
+
+  // ==========================================================================
+  // Estimated Improvement
+  // ==========================================================================
+
+  describe('Estimated Improvement', () => {
+    it('should estimate improvement based on suggestions', () => {
+      const { recommendation, update } = useBandwidthAdaptation()
+
+      update({
+        availableBitrate: 300,
+        currentBitrate: 1500,
+        packetLoss: 5,
+        currentResolution: VIDEO_RESOLUTIONS[0],
+        videoEnabled: true,
+      })
+
+      // Should have positive improvement estimate when there are suggestions
+      if (recommendation.value.suggestions.length > 0) {
+        expect(recommendation.value.estimatedImprovement).toBeGreaterThan(0)
+      }
+    })
+
+    it('should have zero improvement when maintaining', () => {
+      const { recommendation, update } = useBandwidthAdaptation()
+
+      update({
+        availableBitrate: 2000,
+        currentBitrate: 1800,
+        packetLoss: 0.2,
+        rtt: 30,
+      })
+
+      if (recommendation.value.action === 'maintain') {
+        expect(recommendation.value.estimatedImprovement).toBe(0)
+      }
+    })
+
+    it('should cap improvement at 100', () => {
+      const { recommendation, update } = useBandwidthAdaptation()
+
+      update({
+        availableBitrate: 50,
+        currentBitrate: 2000,
+        packetLoss: 20,
+        currentResolution: VIDEO_RESOLUTIONS[0],
+        currentFramerate: 60,
+        currentAudioBitrate: 320,
+        videoEnabled: true,
+      })
+
+      expect(recommendation.value.estimatedImprovement).toBeLessThanOrEqual(100)
+    })
+  })
+
+  // ==========================================================================
+  // Auto-Adaptation
+  // ==========================================================================
+
+  describe('Auto-Adaptation', () => {
+    it('should enable auto-adaptation with setAutoAdapt', () => {
+      const { isAutoAdapting, setAutoAdapt } = useBandwidthAdaptation()
+
+      expect(isAutoAdapting.value).toBe(false)
+
+      setAutoAdapt(true)
+
+      expect(isAutoAdapting.value).toBe(true)
+    })
+
+    it('should disable auto-adaptation with setAutoAdapt', () => {
+      const { isAutoAdapting, setAutoAdapt } = useBandwidthAdaptation({
+        autoAdapt: true,
+      })
+
+      expect(isAutoAdapting.value).toBe(true)
+
+      setAutoAdapt(false)
+
+      expect(isAutoAdapting.value).toBe(false)
+    })
+  })
+
+  // ==========================================================================
+  // Constraints Management
+  // ==========================================================================
+
+  describe('Constraints', () => {
+    it('should update constraints with setConstraints', () => {
+      const { constraints, setConstraints } = useBandwidthAdaptation()
+
+      setConstraints({
+        minVideoBitrate: 300,
+        maxVideoBitrate: 4000,
+      })
+
+      expect(constraints.value.minVideoBitrate).toBe(300)
+      expect(constraints.value.maxVideoBitrate).toBe(4000)
+    })
+
+    it('should merge new constraints with existing ones', () => {
+      const { constraints, setConstraints } = useBandwidthAdaptation()
+
+      setConstraints({ minVideoBitrate: 250 })
+      setConstraints({ maxVideoBitrate: 3500 })
+
+      expect(constraints.value.minVideoBitrate).toBe(250)
+      expect(constraints.value.maxVideoBitrate).toBe(3500)
+    })
+
+    it('should respect minVideoBitrate in recommendations', () => {
+      const { recommendation, update, setConstraints } = useBandwidthAdaptation()
+
+      setConstraints({ minVideoBitrate: 500 })
+
+      update({
+        availableBitrate: 400,
+        currentBitrate: 800,
+        packetLoss: 2,
+        currentResolution: VIDEO_RESOLUTIONS[1],
+        videoEnabled: true,
+      })
+
+      // Should suggest disabling video since we can't meet minimum
+      const videoSuggestion = recommendation.value.suggestions.find((s) => s.type === 'video')
+      expect(videoSuggestion).toBeDefined()
+    })
+
+    it('should respect resolution constraints', () => {
+      const { constraints, setConstraints } = useBandwidthAdaptation()
+
+      const minRes = VIDEO_RESOLUTIONS[3] // 360p
+      setConstraints({ minResolution: minRes })
+
+      expect(constraints.value.minResolution).toEqual(minRes)
+    })
+  })
+
+  // ==========================================================================
+  // Callback on Recommendation
+  // ==========================================================================
+
+  describe('Recommendation Callback', () => {
+    it('should call onRecommendation when recommendation changes', () => {
+      const onRecommendation = vi.fn()
+      const { update } = useBandwidthAdaptation({ onRecommendation })
+
+      update({
+        availableBitrate: 200,
+        currentBitrate: 1000,
+        packetLoss: 5,
+      })
+
+      expect(onRecommendation).toHaveBeenCalled()
+    })
+
+    it('should pass recommendation to callback', () => {
+      const onRecommendation = vi.fn()
+      const { update } = useBandwidthAdaptation({ onRecommendation })
+
+      update({
+        availableBitrate: 200,
+        currentBitrate: 1000,
+        packetLoss: 5,
+      })
+
+      expect(onRecommendation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: expect.any(String),
+          suggestions: expect.any(Array),
+          priority: expect.any(String),
+        })
+      )
+    })
+  })
+
+  // ==========================================================================
+  // Apply Suggestion
+  // ==========================================================================
+
+  describe('Apply Suggestion', () => {
+    it('should provide applySuggestion function', () => {
+      const { applySuggestion } = useBandwidthAdaptation()
+
+      expect(typeof applySuggestion).toBe('function')
+    })
+
+    it('should call applySuggestion without error', () => {
+      const { applySuggestion } = useBandwidthAdaptation()
+
+      const suggestion: AdaptationSuggestion = {
+        type: 'video',
+        message: 'Reduce resolution',
+        current: '1080p',
+        recommended: '720p',
+        impact: 40,
+      }
+
+      expect(() => applySuggestion(suggestion)).not.toThrow()
+    })
+  })
+
+  // ==========================================================================
+  // Reset Functionality
+  // ==========================================================================
+
+  describe('Reset', () => {
+    it('should reset to default state', () => {
+      const { recommendation, isAutoAdapting, update, setAutoAdapt, reset } =
+        useBandwidthAdaptation()
+
+      // Make some changes
+      update({
+        availableBitrate: 100,
+        currentBitrate: 1000,
+        packetLoss: 10,
+      })
+      setAutoAdapt(true)
+
+      expect(recommendation.value.action).toBe('critical')
+      expect(isAutoAdapting.value).toBe(true)
+
+      // Reset
+      reset()
+
+      expect(recommendation.value.action).toBe('maintain')
+      expect(recommendation.value.suggestions).toEqual([])
+      expect(isAutoAdapting.value).toBe(false)
+    })
+
+    it('should reset constraints to defaults', () => {
+      const { constraints, setConstraints, reset } = useBandwidthAdaptation()
+
+      setConstraints({
+        minVideoBitrate: 500,
+        maxVideoBitrate: 10000,
+      })
+
+      reset()
+
+      expect(constraints.value).toEqual(DEFAULT_BANDWIDTH_CONSTRAINTS)
+    })
+  })
+
+  // ==========================================================================
+  // History Smoothing
+  // ==========================================================================
+
+  describe('History Smoothing', () => {
+    it('should smooth recommendations over history window', () => {
+      const { recommendation, update } = useBandwidthAdaptation({
+        historySize: 5,
+      })
+
+      // First update with good conditions
+      update({
+        availableBitrate: 3000,
+        currentBitrate: 1000,
+        packetLoss: 0,
+      })
+
+      // Single bad update shouldn't immediately trigger critical
+      update({
+        availableBitrate: 100,
+        currentBitrate: 1000,
+        packetLoss: 8,
+      })
+
+      // With history smoothing, a single bad sample shouldn't cause critical
+      // (This depends on implementation - adjust expectations as needed)
+      expect(recommendation.value.action).not.toBe('critical')
+    })
+
+    it('should react to sustained poor conditions', () => {
+      const { recommendation, update } = useBandwidthAdaptation({
+        historySize: 3,
+      })
+
+      // Multiple bad updates
+      for (let i = 0; i < 5; i++) {
+        update({
+          availableBitrate: 100,
+          currentBitrate: 1000,
+          packetLoss: 10,
+        })
+      }
+
+      expect(recommendation.value.action).toBe('critical')
+    })
+  })
+
+  // ==========================================================================
+  // Sensitivity
+  // ==========================================================================
+
+  describe('Sensitivity', () => {
+    it('should be more reactive with high sensitivity', () => {
+      const lowSensitivity = useBandwidthAdaptation({ sensitivity: 0.2 })
+      const highSensitivity = useBandwidthAdaptation({ sensitivity: 0.9 })
+
+      const moderateConditions = {
+        availableBitrate: 800,
+        currentBitrate: 1000,
+        packetLoss: 2,
+      }
+
+      lowSensitivity.update(moderateConditions)
+      highSensitivity.update(moderateConditions)
+
+      // High sensitivity should produce higher priority or more aggressive action
+      const lowPriorityOrder = ['low', 'medium', 'high', 'critical']
+      const lowIndex = lowPriorityOrder.indexOf(lowSensitivity.recommendation.value.priority)
+      const highIndex = lowPriorityOrder.indexOf(highSensitivity.recommendation.value.priority)
+
+      expect(highIndex).toBeGreaterThanOrEqual(lowIndex)
+    })
+
+    it('should clamp sensitivity to valid range', () => {
+      const { recommendation, update } = useBandwidthAdaptation({
+        sensitivity: 1.5, // Out of range, should clamp to 1.0
+      })
+
+      update({
+        availableBitrate: 500,
+        currentBitrate: 1000,
+        packetLoss: 3,
+      })
+
+      // Should still work without error
+      expect(recommendation.value).toBeDefined()
+    })
+  })
+
+  // ==========================================================================
+  // Edge Cases
+  // ==========================================================================
+
+  describe('Edge Cases', () => {
+    it('should handle empty update gracefully', () => {
+      const { recommendation, update } = useBandwidthAdaptation()
+
+      update({})
+
+      expect(recommendation.value.action).toBe('maintain')
+    })
+
+    it('should handle zero bitrate values', () => {
+      const { recommendation, update } = useBandwidthAdaptation()
+
+      update({
+        availableBitrate: 0,
+        currentBitrate: 0,
+      })
+
+      expect(recommendation.value.action).toBe('critical')
+    })
+
+    it('should handle negative values as zero', () => {
+      const { recommendation, update } = useBandwidthAdaptation()
+
+      update({
+        availableBitrate: -100,
+        currentBitrate: -50,
+        packetLoss: -5,
+      })
+
+      // Should treat as zero/critical
+      expect(recommendation.value).toBeDefined()
+    })
+
+    it('should handle very high bitrate values', () => {
+      const { recommendation, update } = useBandwidthAdaptation()
+
+      update({
+        availableBitrate: 1000000,
+        currentBitrate: 500000,
+        packetLoss: 0,
+      })
+
+      expect(recommendation.value.action).toBe('upgrade')
+    })
+
+    it('should handle rapid consecutive updates', () => {
+      const { recommendation, update } = useBandwidthAdaptation()
+
+      for (let i = 0; i < 100; i++) {
+        update({
+          availableBitrate: 1000 + i * 10,
+          currentBitrate: 800,
+          packetLoss: i % 5,
+        })
+      }
+
+      expect(recommendation.value).toBeDefined()
+    })
+
+    it('should handle update with only packet loss', () => {
+      const { recommendation, update } = useBandwidthAdaptation()
+
+      update({ packetLoss: 5 })
+
+      expect(recommendation.value.action).not.toBe('maintain')
+    })
+
+    it('should handle update with only RTT', () => {
+      const { recommendation, update } = useBandwidthAdaptation()
+
+      update({ rtt: 500 })
+
+      // High RTT alone should trigger concern
+      expect(['downgrade', 'critical']).toContain(recommendation.value.action)
+    })
+  })
+
+  // ==========================================================================
+  // Timestamp
+  // ==========================================================================
+
+  describe('Timestamp', () => {
+    it('should include timestamp in recommendation', () => {
+      const { recommendation, update } = useBandwidthAdaptation()
+
+      const beforeUpdate = Date.now()
+      update({
+        availableBitrate: 1000,
+        currentBitrate: 800,
+      })
+      const afterUpdate = Date.now()
+
+      expect(recommendation.value.timestamp).toBeGreaterThanOrEqual(beforeUpdate)
+      expect(recommendation.value.timestamp).toBeLessThanOrEqual(afterUpdate)
+    })
+
+    it('should update timestamp on each update', () => {
+      const { recommendation, update } = useBandwidthAdaptation()
+
+      update({ availableBitrate: 1000, currentBitrate: 800 })
+      const firstTimestamp = recommendation.value.timestamp
+
+      vi.advanceTimersByTime(100)
+
+      update({ availableBitrate: 900, currentBitrate: 800 })
+      const secondTimestamp = recommendation.value.timestamp
+
+      expect(secondTimestamp).toBeGreaterThan(firstTimestamp)
+    })
+  })
+
+  // ==========================================================================
+  // Degradation Events
+  // ==========================================================================
+
+  describe('Degradation Events', () => {
+    it('should factor in degradation events for recommendations', () => {
+      const { recommendation, update } = useBandwidthAdaptation()
+
+      // Without degradation events
+      update({
+        availableBitrate: 800,
+        currentBitrate: 1000,
+        packetLoss: 2,
+        degradationEvents: 0,
+      })
+      const priorityWithoutEvents = recommendation.value.priority
+
+      // Reset and try with degradation events
+      const { recommendation: rec2, update: update2 } = useBandwidthAdaptation()
+      update2({
+        availableBitrate: 800,
+        currentBitrate: 1000,
+        packetLoss: 2,
+        degradationEvents: 5,
+      })
+
+      // Degradation events should increase urgency
+      const priorityOrder = ['low', 'medium', 'high', 'critical']
+      expect(priorityOrder.indexOf(rec2.value.priority)).toBeGreaterThanOrEqual(
+        priorityOrder.indexOf(priorityWithoutEvents)
+      )
+    })
+  })
+})

--- a/tests/unit/composables/useCallQualityScore.test.ts
+++ b/tests/unit/composables/useCallQualityScore.test.ts
@@ -1,0 +1,846 @@
+/**
+ * Tests for useCallQualityScore composable
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { useCallQualityScore } from '@/composables/useCallQualityScore'
+import type { QualityScoreWeights } from '@/types/call-quality.types'
+import { DEFAULT_QUALITY_WEIGHTS } from '@/types/call-quality.types'
+
+describe('useCallQualityScore', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  // ==========================================================================
+  // Initialization
+  // ==========================================================================
+
+  describe('Initialization', () => {
+    it('should initialize with null score when no stats provided', () => {
+      const { score, trend, history } = useCallQualityScore()
+
+      expect(score.value).toBeNull()
+      expect(trend.value).toBeNull()
+      expect(history.value).toEqual([])
+    })
+
+    it('should accept custom weight configuration', () => {
+      const customWeights: Partial<QualityScoreWeights> = {
+        packetLoss: 0.4,
+        mos: 0.4,
+        jitter: 0.1,
+        rtt: 0.05,
+        bitrateStability: 0.05,
+      }
+
+      const { weights } = useCallQualityScore({ weights: customWeights })
+
+      expect(weights.value.packetLoss).toBe(0.4)
+      expect(weights.value.mos).toBe(0.4)
+      expect(weights.value.jitter).toBe(0.1)
+    })
+
+    it('should use default weights when not specified', () => {
+      const { weights } = useCallQualityScore()
+
+      expect(weights.value).toEqual(DEFAULT_QUALITY_WEIGHTS)
+    })
+
+    it('should merge partial weights with defaults', () => {
+      const { weights } = useCallQualityScore({
+        weights: { packetLoss: 0.5 },
+      })
+
+      expect(weights.value.packetLoss).toBe(0.5)
+      expect(weights.value.jitter).toBe(DEFAULT_QUALITY_WEIGHTS.jitter)
+      expect(weights.value.rtt).toBe(DEFAULT_QUALITY_WEIGHTS.rtt)
+    })
+  })
+
+  // ==========================================================================
+  // Score Calculation
+  // ==========================================================================
+
+  describe('Score Calculation', () => {
+    it('should calculate overall score from combined metrics', () => {
+      const { score, updateScore } = useCallQualityScore()
+
+      updateScore({
+        packetLoss: 0.5,
+        jitter: 15,
+        rtt: 50,
+        mos: 4.2,
+        bitrate: 1000,
+        previousBitrate: 1000,
+      })
+
+      expect(score.value).not.toBeNull()
+      expect(score.value!.overall).toBeGreaterThan(0)
+      expect(score.value!.overall).toBeLessThanOrEqual(100)
+    })
+
+    it('should weight packet loss correctly', () => {
+      const { score: score1, updateScore: update1 } = useCallQualityScore()
+      const { score: score2, updateScore: update2 } = useCallQualityScore()
+
+      // Low packet loss
+      update1({
+        packetLoss: 0.1,
+        jitter: 20,
+        rtt: 100,
+        mos: 4.0,
+      })
+
+      // High packet loss
+      update2({
+        packetLoss: 5,
+        jitter: 20,
+        rtt: 100,
+        mos: 4.0,
+      })
+
+      expect(score1.value!.overall).toBeGreaterThan(score2.value!.overall)
+    })
+
+    it('should weight jitter correctly', () => {
+      const { score: score1, updateScore: update1 } = useCallQualityScore()
+      const { score: score2, updateScore: update2 } = useCallQualityScore()
+
+      // Low jitter
+      update1({
+        packetLoss: 1,
+        jitter: 5,
+        rtt: 100,
+        mos: 4.0,
+      })
+
+      // High jitter
+      update2({
+        packetLoss: 1,
+        jitter: 100,
+        rtt: 100,
+        mos: 4.0,
+      })
+
+      expect(score1.value!.overall).toBeGreaterThan(score2.value!.overall)
+    })
+
+    it('should weight RTT correctly', () => {
+      const { score: score1, updateScore: update1 } = useCallQualityScore()
+      const { score: score2, updateScore: update2 } = useCallQualityScore()
+
+      // Low RTT
+      update1({
+        packetLoss: 1,
+        jitter: 20,
+        rtt: 30,
+        mos: 4.0,
+      })
+
+      // High RTT
+      update2({
+        packetLoss: 1,
+        jitter: 20,
+        rtt: 500,
+        mos: 4.0,
+      })
+
+      expect(score1.value!.overall).toBeGreaterThan(score2.value!.overall)
+    })
+
+    it('should weight MOS correctly', () => {
+      const { score: score1, updateScore: update1 } = useCallQualityScore()
+      const { score: score2, updateScore: update2 } = useCallQualityScore()
+
+      // High MOS
+      update1({
+        packetLoss: 1,
+        jitter: 20,
+        rtt: 100,
+        mos: 4.5,
+      })
+
+      // Low MOS
+      update2({
+        packetLoss: 1,
+        jitter: 20,
+        rtt: 100,
+        mos: 2.5,
+      })
+
+      expect(score1.value!.overall).toBeGreaterThan(score2.value!.overall)
+    })
+
+    it('should weight bitrate stability correctly', () => {
+      const { score: score1, updateScore: update1 } = useCallQualityScore()
+      const { score: score2, updateScore: update2 } = useCallQualityScore()
+
+      // Stable bitrate
+      update1({
+        packetLoss: 1,
+        jitter: 20,
+        rtt: 100,
+        mos: 4.0,
+        bitrate: 1000,
+        previousBitrate: 1000,
+      })
+
+      // Unstable bitrate (50% drop)
+      update2({
+        packetLoss: 1,
+        jitter: 20,
+        rtt: 100,
+        mos: 4.0,
+        bitrate: 500,
+        previousBitrate: 1000,
+      })
+
+      expect(score1.value!.overall).toBeGreaterThan(score2.value!.overall)
+    })
+
+    it('should return 100 for perfect metrics', () => {
+      const { score, updateScore } = useCallQualityScore()
+
+      updateScore({
+        packetLoss: 0,
+        jitter: 0,
+        rtt: 0,
+        mos: 5.0,
+        bitrate: 1000,
+        previousBitrate: 1000,
+      })
+
+      expect(score.value!.overall).toBe(100)
+    })
+
+    it('should return low score for worst-case metrics', () => {
+      const { score, updateScore } = useCallQualityScore()
+
+      updateScore({
+        packetLoss: 20,
+        jitter: 200,
+        rtt: 1000,
+        mos: 1.0,
+        bitrate: 100,
+        previousBitrate: 1000,
+      })
+
+      expect(score.value!.overall).toBeLessThan(30)
+    })
+
+    it('should handle partial metrics gracefully', () => {
+      const { score, updateScore } = useCallQualityScore()
+
+      // Only provide some metrics
+      updateScore({
+        packetLoss: 1,
+        rtt: 100,
+      })
+
+      expect(score.value).not.toBeNull()
+      expect(score.value!.overall).toBeGreaterThan(0)
+    })
+  })
+
+  // ==========================================================================
+  // Audio Quality Score
+  // ==========================================================================
+
+  describe('Audio Quality Score', () => {
+    it('should calculate audio score from audio-specific metrics', () => {
+      const { score, updateScore } = useCallQualityScore()
+
+      updateScore({
+        audioPacketLoss: 0.5,
+        audioJitterBufferDelay: 20,
+        mos: 4.2,
+      })
+
+      expect(score.value!.audio).toBeGreaterThan(70)
+    })
+
+    it('should prioritize audio codec quality through MOS', () => {
+      const { score: score1, updateScore: update1 } = useCallQualityScore()
+      const { score: score2, updateScore: update2 } = useCallQualityScore()
+
+      update1({
+        audioPacketLoss: 0.5,
+        mos: 4.5, // High MOS = good codec
+      })
+
+      update2({
+        audioPacketLoss: 0.5,
+        mos: 3.0, // Low MOS = poor codec
+      })
+
+      expect(score1.value!.audio).toBeGreaterThan(score2.value!.audio)
+    })
+
+    it('should factor in audio jitter buffer delay', () => {
+      const { score: score1, updateScore: update1 } = useCallQualityScore()
+      const { score: score2, updateScore: update2 } = useCallQualityScore()
+
+      update1({
+        audioJitterBufferDelay: 10, // Low delay
+        mos: 4.0,
+      })
+
+      update2({
+        audioJitterBufferDelay: 100, // High delay
+        mos: 4.0,
+      })
+
+      expect(score1.value!.audio).toBeGreaterThan(score2.value!.audio)
+    })
+
+    it('should consider audio packet loss specifically', () => {
+      const { score: score1, updateScore: update1 } = useCallQualityScore()
+      const { score: score2, updateScore: update2 } = useCallQualityScore()
+
+      update1({
+        audioPacketLoss: 0.1,
+        mos: 4.0,
+      })
+
+      update2({
+        audioPacketLoss: 3,
+        mos: 4.0,
+      })
+
+      expect(score1.value!.audio).toBeGreaterThan(score2.value!.audio)
+    })
+  })
+
+  // ==========================================================================
+  // Video Quality Score
+  // ==========================================================================
+
+  describe('Video Quality Score', () => {
+    it('should calculate video score from video-specific metrics', () => {
+      const { score, updateScore } = useCallQualityScore()
+
+      updateScore({
+        videoPacketLoss: 0.5,
+        framerate: 28,
+        targetFramerate: 30,
+        resolutionWidth: 1280,
+        resolutionHeight: 720,
+        audioOnly: false,
+      })
+
+      expect(score.value!.video).not.toBeNull()
+      expect(score.value!.video).toBeGreaterThan(70)
+    })
+
+    it('should return null for audio-only calls', () => {
+      const { score, updateScore } = useCallQualityScore()
+
+      updateScore({
+        audioPacketLoss: 0.5,
+        mos: 4.2,
+        audioOnly: true,
+      })
+
+      expect(score.value!.video).toBeNull()
+    })
+
+    it('should factor in resolution and framerate', () => {
+      const { score: score1, updateScore: update1 } = useCallQualityScore()
+      const { score: score2, updateScore: update2 } = useCallQualityScore()
+
+      // High resolution and framerate
+      update1({
+        framerate: 30,
+        targetFramerate: 30,
+        resolutionWidth: 1920,
+        resolutionHeight: 1080,
+        audioOnly: false,
+      })
+
+      // Low resolution and framerate
+      update2({
+        framerate: 15,
+        targetFramerate: 30,
+        resolutionWidth: 640,
+        resolutionHeight: 360,
+        audioOnly: false,
+      })
+
+      expect(score1.value!.video).toBeGreaterThan(score2.value!.video!)
+    })
+
+    it('should consider video packet loss specifically', () => {
+      const { score: score1, updateScore: update1 } = useCallQualityScore()
+      const { score: score2, updateScore: update2 } = useCallQualityScore()
+
+      update1({
+        videoPacketLoss: 0.1,
+        framerate: 30,
+        targetFramerate: 30,
+        audioOnly: false,
+      })
+
+      update2({
+        videoPacketLoss: 5,
+        framerate: 30,
+        targetFramerate: 30,
+        audioOnly: false,
+      })
+
+      expect(score1.value!.video).toBeGreaterThan(score2.value!.video!)
+    })
+
+    it('should account for freeze events', () => {
+      const { score: score1, updateScore: update1 } = useCallQualityScore()
+      const { score: score2, updateScore: update2 } = useCallQualityScore()
+
+      update1({
+        framerate: 30,
+        targetFramerate: 30,
+        freezeCount: 0,
+        audioOnly: false,
+      })
+
+      update2({
+        framerate: 30,
+        targetFramerate: 30,
+        freezeCount: 5,
+        audioOnly: false,
+      })
+
+      expect(score1.value!.video).toBeGreaterThan(score2.value!.video!)
+    })
+  })
+
+  // ==========================================================================
+  // Network Score
+  // ==========================================================================
+
+  describe('Network Score', () => {
+    it('should calculate network score from connection metrics', () => {
+      const { score, updateScore } = useCallQualityScore()
+
+      updateScore({
+        rtt: 50,
+        jitter: 10,
+        packetLoss: 0.5,
+      })
+
+      expect(score.value!.network).toBeGreaterThan(70)
+    })
+
+    it('should factor in RTT heavily', () => {
+      const { score: score1, updateScore: update1 } = useCallQualityScore()
+      const { score: score2, updateScore: update2 } = useCallQualityScore()
+
+      update1({
+        rtt: 20,
+        jitter: 20,
+        packetLoss: 1,
+      })
+
+      update2({
+        rtt: 400,
+        jitter: 20,
+        packetLoss: 1,
+      })
+
+      // RTT should have major impact on network score
+      expect(score1.value!.network - score2.value!.network).toBeGreaterThan(20)
+    })
+
+    it('should consider jitter as network instability', () => {
+      const { score: score1, updateScore: update1 } = useCallQualityScore()
+      const { score: score2, updateScore: update2 } = useCallQualityScore()
+
+      update1({
+        rtt: 100,
+        jitter: 5,
+        packetLoss: 1,
+      })
+
+      update2({
+        rtt: 100,
+        jitter: 80,
+        packetLoss: 1,
+      })
+
+      expect(score1.value!.network).toBeGreaterThan(score2.value!.network)
+    })
+
+    it('should handle missing network metrics', () => {
+      const { score, updateScore } = useCallQualityScore()
+
+      updateScore({
+        mos: 4.0,
+        // No RTT, jitter, or packet loss
+      })
+
+      // Should still produce a network score using defaults
+      expect(score.value!.network).toBeDefined()
+    })
+  })
+
+  // ==========================================================================
+  // Grade Assignment
+  // ==========================================================================
+
+  describe('Grade Assignment', () => {
+    it('should assign grade A for scores >= 90', () => {
+      const { score, updateScore } = useCallQualityScore()
+
+      updateScore({
+        packetLoss: 0,
+        jitter: 5,
+        rtt: 20,
+        mos: 4.8,
+        bitrate: 1000,
+        previousBitrate: 1000,
+      })
+
+      expect(score.value!.grade).toBe('A')
+    })
+
+    it('should assign grade B for scores >= 75', () => {
+      const { score, updateScore } = useCallQualityScore()
+
+      // Slightly degraded metrics to target B grade range (75-89)
+      updateScore({
+        packetLoss: 1.2,
+        jitter: 30,
+        rtt: 100,
+        mos: 3.9,
+        bitrate: 900,
+        previousBitrate: 1000,
+      })
+
+      expect(score.value!.overall).toBeGreaterThanOrEqual(75)
+      expect(score.value!.overall).toBeLessThan(90)
+      expect(score.value!.grade).toBe('B')
+    })
+
+    it('should assign grade C for scores >= 60', () => {
+      const { score, updateScore } = useCallQualityScore()
+
+      updateScore({
+        packetLoss: 2,
+        jitter: 40,
+        rtt: 150,
+        mos: 3.5,
+      })
+
+      expect(score.value!.overall).toBeGreaterThanOrEqual(60)
+      expect(score.value!.overall).toBeLessThan(75)
+      expect(score.value!.grade).toBe('C')
+    })
+
+    it('should assign grade D for scores >= 40', () => {
+      const { score, updateScore } = useCallQualityScore()
+
+      updateScore({
+        packetLoss: 5,
+        jitter: 80,
+        rtt: 300,
+        mos: 2.8,
+      })
+
+      expect(score.value!.overall).toBeGreaterThanOrEqual(40)
+      expect(score.value!.overall).toBeLessThan(60)
+      expect(score.value!.grade).toBe('D')
+    })
+
+    it('should assign grade F for scores < 40', () => {
+      const { score, updateScore } = useCallQualityScore()
+
+      updateScore({
+        packetLoss: 15,
+        jitter: 150,
+        rtt: 600,
+        mos: 1.5,
+      })
+
+      expect(score.value!.overall).toBeLessThan(40)
+      expect(score.value!.grade).toBe('F')
+    })
+  })
+
+  // ==========================================================================
+  // Quality Trend
+  // ==========================================================================
+
+  describe('Quality Trend', () => {
+    it('should detect improving quality trend', () => {
+      const { trend, updateScore } = useCallQualityScore({ enableTrendAnalysis: true })
+
+      // Simulate improving quality over time
+      const mosValues = [3.0, 3.2, 3.5, 3.8, 4.0, 4.2, 4.4]
+
+      for (const mos of mosValues) {
+        updateScore({ mos, rtt: 100, packetLoss: 1 })
+        vi.advanceTimersByTime(1000)
+      }
+
+      expect(trend.value).not.toBeNull()
+      expect(trend.value!.direction).toBe('improving')
+      expect(trend.value!.rate).toBeGreaterThan(0)
+    })
+
+    it('should detect stable quality', () => {
+      const { trend, updateScore } = useCallQualityScore({ enableTrendAnalysis: true })
+
+      // Simulate stable quality
+      for (let i = 0; i < 7; i++) {
+        updateScore({ mos: 4.0, rtt: 100, packetLoss: 1 })
+        vi.advanceTimersByTime(1000)
+      }
+
+      expect(trend.value).not.toBeNull()
+      expect(trend.value!.direction).toBe('stable')
+    })
+
+    it('should detect degrading quality trend', () => {
+      const { trend, updateScore } = useCallQualityScore({ enableTrendAnalysis: true })
+
+      // Simulate degrading quality over time
+      const mosValues = [4.4, 4.2, 4.0, 3.8, 3.5, 3.2, 3.0]
+
+      for (const mos of mosValues) {
+        updateScore({ mos, rtt: 100, packetLoss: 1 })
+        vi.advanceTimersByTime(1000)
+      }
+
+      expect(trend.value).not.toBeNull()
+      expect(trend.value!.direction).toBe('degrading')
+      expect(trend.value!.rate).toBeLessThan(0)
+    })
+
+    it('should calculate trend rate correctly', () => {
+      const { trend, updateScore } = useCallQualityScore({ enableTrendAnalysis: true })
+
+      // Large improvement - MOS 2.0 to 4.0 is a 50-point score change over 5 samples
+      updateScore({ mos: 2.0, rtt: 100, packetLoss: 1 })
+      vi.advanceTimersByTime(1000)
+      updateScore({ mos: 2.5, rtt: 100, packetLoss: 1 })
+      vi.advanceTimersByTime(1000)
+      updateScore({ mos: 3.0, rtt: 100, packetLoss: 1 })
+      vi.advanceTimersByTime(1000)
+      updateScore({ mos: 3.5, rtt: 100, packetLoss: 1 })
+      vi.advanceTimersByTime(1000)
+      updateScore({ mos: 4.0, rtt: 100, packetLoss: 1 })
+
+      expect(trend.value!.rate).toBeGreaterThan(2) // Positive rate indicating improvement
+    })
+
+    it('should require minimum history for trend confidence', () => {
+      const { trend, updateScore } = useCallQualityScore({
+        enableTrendAnalysis: true,
+        historySize: 10,
+      })
+
+      // Only 2 data points - not enough for confident trend
+      updateScore({ mos: 3.0, rtt: 100, packetLoss: 1 })
+      vi.advanceTimersByTime(1000)
+      updateScore({ mos: 4.0, rtt: 100, packetLoss: 1 })
+
+      // Trend may exist but confidence should be low
+      if (trend.value) {
+        expect(trend.value.confidence).toBeLessThan(0.5)
+      }
+    })
+
+    it('should not calculate trend when disabled', () => {
+      const { trend, updateScore } = useCallQualityScore({ enableTrendAnalysis: false })
+
+      for (let i = 0; i < 10; i++) {
+        updateScore({ mos: 3.0 + i * 0.1, rtt: 100, packetLoss: 1 })
+        vi.advanceTimersByTime(1000)
+      }
+
+      expect(trend.value).toBeNull()
+    })
+  })
+
+  // ==========================================================================
+  // Description Generation
+  // ==========================================================================
+
+  describe('Description Generation', () => {
+    it('should generate "Excellent call quality" for A grade', () => {
+      const { score, updateScore } = useCallQualityScore()
+
+      updateScore({
+        packetLoss: 0,
+        jitter: 5,
+        rtt: 20,
+        mos: 4.8,
+      })
+
+      expect(score.value!.description.toLowerCase()).toContain('excellent')
+    })
+
+    it('should generate "Good call quality" for B grade', () => {
+      const { score, updateScore } = useCallQualityScore()
+
+      // Slightly degraded metrics to target B grade range (75-89)
+      updateScore({
+        packetLoss: 1.2,
+        jitter: 30,
+        rtt: 100,
+        mos: 3.9,
+        bitrate: 900,
+        previousBitrate: 1000,
+      })
+
+      expect(score.value!.description.toLowerCase()).toContain('good')
+    })
+
+    it('should include specific issues in lower grades', () => {
+      const { score, updateScore } = useCallQualityScore()
+
+      updateScore({
+        packetLoss: 8,
+        jitter: 20,
+        rtt: 100,
+        mos: 3.0,
+      })
+
+      // Should mention the high packet loss
+      expect(score.value!.description.toLowerCase()).toMatch(/packet loss|loss/)
+    })
+
+    it('should mention network issues when network score is low', () => {
+      const { score, updateScore } = useCallQualityScore()
+
+      updateScore({
+        packetLoss: 1,
+        jitter: 100,
+        rtt: 500,
+        mos: 3.5,
+      })
+
+      // Should mention network-related issues
+      expect(score.value!.description.toLowerCase()).toMatch(/network|latency|delay/)
+    })
+  })
+
+  // ==========================================================================
+  // History Management
+  // ==========================================================================
+
+  describe('History Management', () => {
+    it('should add scores to history', () => {
+      const { history, updateScore } = useCallQualityScore()
+
+      updateScore({ mos: 4.0, rtt: 100, packetLoss: 1 })
+      vi.advanceTimersByTime(1000)
+      updateScore({ mos: 4.2, rtt: 90, packetLoss: 0.5 })
+
+      expect(history.value.length).toBe(2)
+    })
+
+    it('should limit history to configured size', () => {
+      const { history, updateScore } = useCallQualityScore({ historySize: 5 })
+
+      for (let i = 0; i < 10; i++) {
+        updateScore({ mos: 4.0, rtt: 100, packetLoss: 1 })
+        vi.advanceTimersByTime(1000)
+      }
+
+      expect(history.value.length).toBe(5)
+    })
+
+    it('should clear history on reset', () => {
+      const { history, updateScore, reset } = useCallQualityScore()
+
+      updateScore({ mos: 4.0, rtt: 100, packetLoss: 1 })
+      vi.advanceTimersByTime(1000)
+      updateScore({ mos: 4.2, rtt: 90, packetLoss: 0.5 })
+
+      expect(history.value.length).toBe(2)
+
+      reset()
+
+      expect(history.value.length).toBe(0)
+    })
+
+    it('should reset score to null on reset', () => {
+      const { score, updateScore, reset } = useCallQualityScore()
+
+      updateScore({ mos: 4.0, rtt: 100, packetLoss: 1 })
+      expect(score.value).not.toBeNull()
+
+      reset()
+
+      expect(score.value).toBeNull()
+    })
+  })
+
+  // ==========================================================================
+  // Edge Cases
+  // ==========================================================================
+
+  describe('Edge Cases', () => {
+    it('should handle zero values correctly', () => {
+      const { score, updateScore } = useCallQualityScore()
+
+      updateScore({
+        packetLoss: 0,
+        jitter: 0,
+        rtt: 0,
+        mos: 5.0,
+      })
+
+      expect(score.value!.overall).toBe(100)
+    })
+
+    it('should clamp MOS to valid range', () => {
+      const { score, updateScore } = useCallQualityScore()
+
+      // MOS above 5 should be treated as 5
+      updateScore({ mos: 6.0, rtt: 100, packetLoss: 1 })
+
+      expect(score.value).not.toBeNull()
+      expect(score.value!.overall).toBeLessThanOrEqual(100)
+    })
+
+    it('should handle negative values gracefully', () => {
+      const { score, updateScore } = useCallQualityScore()
+
+      // Negative values shouldn't break the calculation
+      updateScore({
+        packetLoss: -1, // Invalid
+        jitter: 20,
+        rtt: 100,
+        mos: 4.0,
+      })
+
+      expect(score.value).not.toBeNull()
+    })
+
+    it('should handle very large values', () => {
+      const { score, updateScore } = useCallQualityScore()
+
+      updateScore({
+        packetLoss: 100,
+        jitter: 10000,
+        rtt: 10000,
+        mos: 1.0,
+      })
+
+      expect(score.value!.overall).toBeGreaterThanOrEqual(0)
+      expect(score.value!.overall).toBeLessThanOrEqual(100)
+    })
+
+    it('should include timestamp in score', () => {
+      const { score, updateScore } = useCallQualityScore()
+
+      const before = Date.now()
+      updateScore({ mos: 4.0, rtt: 100, packetLoss: 1 })
+      const after = Date.now()
+
+      expect(score.value!.timestamp).toBeGreaterThanOrEqual(before)
+      expect(score.value!.timestamp).toBeLessThanOrEqual(after)
+    })
+  })
+})

--- a/tests/unit/composables/useNetworkQualityIndicator.test.ts
+++ b/tests/unit/composables/useNetworkQualityIndicator.test.ts
@@ -1,0 +1,775 @@
+/**
+ * Tests for useNetworkQualityIndicator composable
+ *
+ * TDD specifications for network quality indicator functionality
+ * including quality level detection, signal bars, colors, and accessibility.
+ */
+
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest'
+import { useNetworkQualityIndicator } from '@/composables/useNetworkQualityIndicator'
+import { DEFAULT_NETWORK_COLORS, type NetworkQualityLevel } from '@/types/call-quality.types'
+
+describe('useNetworkQualityIndicator', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  // ==========================================================================
+  // Initialization and Default State
+  // ==========================================================================
+
+  describe('Initialization', () => {
+    it('should initialize with unknown state when no data provided', () => {
+      const { indicator, isAvailable } = useNetworkQualityIndicator()
+
+      expect(isAvailable.value).toBe(false)
+      expect(indicator.value.level).toBe('unknown')
+      expect(indicator.value.bars).toBe(1)
+      expect(indicator.value.icon).toBe('signal-unknown')
+      expect(indicator.value.color).toBe(DEFAULT_NETWORK_COLORS.unknown)
+    })
+
+    it('should have proper default details structure', () => {
+      const { indicator } = useNetworkQualityIndicator()
+
+      expect(indicator.value.details).toEqual({
+        rtt: 0,
+        jitter: 0,
+        packetLoss: 0,
+        bandwidth: 0,
+        connectionType: 'unknown',
+      })
+    })
+
+    it('should accept custom color scheme', () => {
+      const customColors = {
+        excellent: '#00ff00',
+        poor: '#ff0000',
+      }
+      const { indicator, update } = useNetworkQualityIndicator({
+        colors: customColors,
+      })
+
+      // Update to excellent quality
+      update({ rtt: 20, jitter: 5, packetLoss: 0.1 })
+
+      expect(indicator.value.color).toBe('#00ff00')
+    })
+
+    it('should accept custom thresholds', () => {
+      const customThresholds = {
+        rtt: [25, 50, 100, 200] as [number, number, number, number],
+      }
+      const { indicator, update } = useNetworkQualityIndicator({
+        thresholds: customThresholds,
+      })
+
+      // With default thresholds, 30ms RTT would be excellent
+      // With custom thresholds (25 for excellent), 30ms should be good
+      update({ rtt: 30, jitter: 5, packetLoss: 0 })
+
+      expect(indicator.value.level).toBe('good')
+    })
+  })
+
+  // ==========================================================================
+  // Quality Level Detection
+  // ==========================================================================
+
+  describe('Quality Level Detection', () => {
+    describe('Excellent Quality', () => {
+      it('should detect excellent quality with optimal metrics', () => {
+        const { indicator, update } = useNetworkQualityIndicator()
+
+        update({
+          rtt: 20,
+          jitter: 5,
+          packetLoss: 0.1,
+        })
+
+        expect(indicator.value.level).toBe('excellent')
+        expect(indicator.value.bars).toBe(5)
+        expect(indicator.value.icon).toBe('signal-excellent')
+      })
+
+      it('should detect excellent when all metrics are at threshold boundaries', () => {
+        const { indicator, update } = useNetworkQualityIndicator()
+
+        update({
+          rtt: 50, // Exactly at excellent threshold
+          jitter: 10,
+          packetLoss: 0.5,
+        })
+
+        expect(indicator.value.level).toBe('excellent')
+      })
+    })
+
+    describe('Good Quality', () => {
+      it('should detect good quality with slightly elevated metrics', () => {
+        const { indicator, update } = useNetworkQualityIndicator()
+
+        update({
+          rtt: 75,
+          jitter: 15,
+          packetLoss: 0.8,
+        })
+
+        expect(indicator.value.level).toBe('good')
+        expect(indicator.value.bars).toBe(4)
+        expect(indicator.value.icon).toBe('signal-good')
+      })
+
+      it('should detect good when one metric is in good range', () => {
+        const { indicator, update } = useNetworkQualityIndicator()
+
+        update({
+          rtt: 80, // Good range (50-100)
+          jitter: 5, // Excellent
+          packetLoss: 0.2, // Excellent
+        })
+
+        expect(indicator.value.level).toBe('good')
+      })
+    })
+
+    describe('Fair Quality', () => {
+      it('should detect fair quality with moderate issues', () => {
+        const { indicator, update } = useNetworkQualityIndicator()
+
+        update({
+          rtt: 150,
+          jitter: 30,
+          packetLoss: 1.5,
+        })
+
+        expect(indicator.value.level).toBe('fair')
+        expect(indicator.value.bars).toBe(3)
+        expect(indicator.value.icon).toBe('signal-fair')
+      })
+    })
+
+    describe('Poor Quality', () => {
+      it('should detect poor quality with significant issues', () => {
+        const { indicator, update } = useNetworkQualityIndicator()
+
+        update({
+          rtt: 300,
+          jitter: 60,
+          packetLoss: 3,
+        })
+
+        expect(indicator.value.level).toBe('poor')
+        expect(indicator.value.bars).toBe(2)
+        expect(indicator.value.icon).toBe('signal-poor')
+      })
+    })
+
+    describe('Critical Quality', () => {
+      it('should detect critical quality with severe issues', () => {
+        const { indicator, update } = useNetworkQualityIndicator()
+
+        update({
+          rtt: 500,
+          jitter: 100,
+          packetLoss: 10,
+        })
+
+        expect(indicator.value.level).toBe('critical')
+        expect(indicator.value.bars).toBe(1)
+        expect(indicator.value.icon).toBe('signal-critical')
+      })
+
+      it('should detect critical when any metric exceeds worst threshold', () => {
+        const { indicator, update } = useNetworkQualityIndicator()
+
+        // Only packet loss is critical
+        update({
+          rtt: 50, // Excellent
+          jitter: 10, // Excellent
+          packetLoss: 8, // Critical (>5%)
+        })
+
+        expect(indicator.value.level).toBe('critical')
+      })
+    })
+
+    describe('Worst Metric Determines Level', () => {
+      it('should use worst metric to determine quality level', () => {
+        const { indicator, update } = useNetworkQualityIndicator()
+
+        // Two excellent, one poor
+        update({
+          rtt: 20, // Excellent
+          jitter: 5, // Excellent
+          packetLoss: 3.5, // Poor (2-5%)
+        })
+
+        expect(indicator.value.level).toBe('poor')
+      })
+
+      it('should handle mixed quality levels correctly', () => {
+        const { indicator, update } = useNetworkQualityIndicator()
+
+        update({
+          rtt: 150, // Fair (100-200)
+          jitter: 15, // Good (10-20)
+          packetLoss: 0.3, // Excellent (<0.5)
+        })
+
+        expect(indicator.value.level).toBe('fair')
+      })
+    })
+  })
+
+  // ==========================================================================
+  // Signal Bars Mapping
+  // ==========================================================================
+
+  describe('Signal Bars', () => {
+    it.each([
+      ['excellent', 5],
+      ['good', 4],
+      ['fair', 3],
+      ['poor', 2],
+      ['critical', 1],
+      ['unknown', 1],
+    ] as [NetworkQualityLevel, number][])(
+      'should return %i bars for %s quality',
+      (level, expectedBars) => {
+        const { indicator, update, reset } = useNetworkQualityIndicator()
+
+        if (level === 'unknown') {
+          reset()
+        } else {
+          // Use metrics that produce each quality level
+          const metricsForLevel = {
+            excellent: { rtt: 20, jitter: 5, packetLoss: 0.1 },
+            good: { rtt: 75, jitter: 15, packetLoss: 0.7 },
+            fair: { rtt: 150, jitter: 30, packetLoss: 1.5 },
+            poor: { rtt: 300, jitter: 60, packetLoss: 3 },
+            critical: { rtt: 500, jitter: 100, packetLoss: 10 },
+          }
+          update(metricsForLevel[level])
+        }
+
+        expect(indicator.value.bars).toBe(expectedBars)
+      }
+    )
+  })
+
+  // ==========================================================================
+  // Color Mapping
+  // ==========================================================================
+
+  describe('Colors', () => {
+    it('should use default colors when not customized', () => {
+      const { indicator, update } = useNetworkQualityIndicator()
+
+      update({ rtt: 20, jitter: 5, packetLoss: 0.1 })
+      expect(indicator.value.color).toBe(DEFAULT_NETWORK_COLORS.excellent)
+
+      update({ rtt: 500, jitter: 100, packetLoss: 10 })
+      expect(indicator.value.color).toBe(DEFAULT_NETWORK_COLORS.critical)
+    })
+
+    it('should merge custom colors with defaults', () => {
+      const customColors = {
+        excellent: '#00ff00',
+      }
+      const { indicator, update } = useNetworkQualityIndicator({
+        colors: customColors,
+      })
+
+      update({ rtt: 20, jitter: 5, packetLoss: 0.1 })
+      expect(indicator.value.color).toBe('#00ff00')
+
+      // Other levels should still use defaults
+      update({ rtt: 500, jitter: 100, packetLoss: 10 })
+      expect(indicator.value.color).toBe(DEFAULT_NETWORK_COLORS.critical)
+    })
+  })
+
+  // ==========================================================================
+  // Icon Mapping
+  // ==========================================================================
+
+  describe('Icons', () => {
+    it.each([
+      ['excellent', 'signal-excellent'],
+      ['good', 'signal-good'],
+      ['fair', 'signal-fair'],
+      ['poor', 'signal-poor'],
+      ['critical', 'signal-critical'],
+    ] as [NetworkQualityLevel, string][])(
+      'should return %s icon for %s quality',
+      (level, expectedIcon) => {
+        const { indicator, update } = useNetworkQualityIndicator()
+
+        const metricsForLevel = {
+          excellent: { rtt: 20, jitter: 5, packetLoss: 0.1 },
+          good: { rtt: 75, jitter: 15, packetLoss: 0.7 },
+          fair: { rtt: 150, jitter: 30, packetLoss: 1.5 },
+          poor: { rtt: 300, jitter: 60, packetLoss: 3 },
+          critical: { rtt: 500, jitter: 100, packetLoss: 10 },
+        }
+        update(metricsForLevel[level])
+
+        expect(indicator.value.icon).toBe(expectedIcon)
+      }
+    )
+  })
+
+  // ==========================================================================
+  // Accessibility Labels
+  // ==========================================================================
+
+  describe('Accessibility', () => {
+    it('should generate descriptive aria labels', () => {
+      const { indicator, update } = useNetworkQualityIndicator()
+
+      update({ rtt: 20, jitter: 5, packetLoss: 0.1 })
+
+      expect(indicator.value.ariaLabel).toContain('excellent')
+      expect(indicator.value.ariaLabel.toLowerCase()).toMatch(/network|connection|quality/)
+    })
+
+    it('should update aria label when quality changes', () => {
+      const { indicator, update } = useNetworkQualityIndicator()
+
+      update({ rtt: 20, jitter: 5, packetLoss: 0.1 })
+      const excellentLabel = indicator.value.ariaLabel
+
+      update({ rtt: 500, jitter: 100, packetLoss: 10 })
+      const criticalLabel = indicator.value.ariaLabel
+
+      expect(excellentLabel).not.toBe(criticalLabel)
+      expect(criticalLabel).toContain('critical')
+    })
+
+    it('should have aria label for unknown state', () => {
+      const { indicator } = useNetworkQualityIndicator()
+
+      expect(indicator.value.ariaLabel).toBeTruthy()
+      expect(indicator.value.ariaLabel.toLowerCase()).toMatch(/unknown|no data|unavailable/)
+    })
+  })
+
+  // ==========================================================================
+  // Network Details
+  // ==========================================================================
+
+  describe('Network Details', () => {
+    it('should update details with provided metrics', () => {
+      const { indicator, update } = useNetworkQualityIndicator()
+
+      update({
+        rtt: 75,
+        jitter: 15,
+        packetLoss: 0.8,
+        bitrate: 1500,
+        candidateType: 'host',
+      })
+
+      expect(indicator.value.details.rtt).toBe(75)
+      expect(indicator.value.details.jitter).toBe(15)
+      expect(indicator.value.details.packetLoss).toBe(0.8)
+      expect(indicator.value.details.connectionType).toBe('host')
+    })
+
+    it('should estimate bandwidth from bitrate when available', () => {
+      const { indicator, update } = useNetworkQualityIndicator({
+        estimateBandwidth: true,
+      })
+
+      update({
+        rtt: 50,
+        jitter: 10,
+        packetLoss: 0.3,
+        bitrate: 2000,
+      })
+
+      expect(indicator.value.details.bandwidth).toBeGreaterThan(0)
+    })
+
+    it('should use availableOutgoingBitrate for bandwidth when provided', () => {
+      const { indicator, update } = useNetworkQualityIndicator()
+
+      update({
+        rtt: 50,
+        jitter: 10,
+        packetLoss: 0.3,
+        availableOutgoingBitrate: 3000,
+      })
+
+      expect(indicator.value.details.bandwidth).toBe(3000)
+    })
+
+    it('should preserve previous values for missing metrics', () => {
+      const { indicator, update } = useNetworkQualityIndicator()
+
+      // First update with full data
+      update({
+        rtt: 75,
+        jitter: 15,
+        packetLoss: 0.8,
+        candidateType: 'relay',
+      })
+
+      // Second update with partial data
+      update({
+        rtt: 100,
+        // jitter, packetLoss, candidateType not provided
+      })
+
+      expect(indicator.value.details.rtt).toBe(100)
+      expect(indicator.value.details.jitter).toBe(15) // Preserved
+      expect(indicator.value.details.packetLoss).toBe(0.8) // Preserved
+      expect(indicator.value.details.connectionType).toBe('relay') // Preserved
+    })
+  })
+
+  // ==========================================================================
+  // Update Behavior
+  // ==========================================================================
+
+  describe('Update Behavior', () => {
+    it('should set isAvailable to true after first update', () => {
+      const { isAvailable, update } = useNetworkQualityIndicator()
+
+      expect(isAvailable.value).toBe(false)
+
+      update({ rtt: 50 })
+
+      expect(isAvailable.value).toBe(true)
+    })
+
+    it('should handle updates with only RTT', () => {
+      const { indicator, update } = useNetworkQualityIndicator()
+
+      update({ rtt: 30 })
+
+      expect(indicator.value.level).not.toBe('unknown')
+      expect(indicator.value.details.rtt).toBe(30)
+    })
+
+    it('should handle updates with only jitter', () => {
+      const { indicator, update } = useNetworkQualityIndicator()
+
+      update({ jitter: 15 })
+
+      expect(indicator.value.level).not.toBe('unknown')
+      expect(indicator.value.details.jitter).toBe(15)
+    })
+
+    it('should handle updates with only packet loss', () => {
+      const { indicator, update } = useNetworkQualityIndicator()
+
+      update({ packetLoss: 0.5 })
+
+      expect(indicator.value.level).not.toBe('unknown')
+      expect(indicator.value.details.packetLoss).toBe(0.5)
+    })
+
+    it('should handle empty updates gracefully', () => {
+      const { indicator, isAvailable, update } = useNetworkQualityIndicator()
+
+      update({})
+
+      // Should remain in unknown state with empty update
+      expect(isAvailable.value).toBe(false)
+      expect(indicator.value.level).toBe('unknown')
+    })
+  })
+
+  // ==========================================================================
+  // Reset Functionality
+  // ==========================================================================
+
+  describe('Reset', () => {
+    it('should reset to unknown state', () => {
+      const { indicator, isAvailable, update, reset } = useNetworkQualityIndicator()
+
+      // First update to good state
+      update({ rtt: 50, jitter: 10, packetLoss: 0.3 })
+      expect(isAvailable.value).toBe(true)
+      expect(indicator.value.level).toBe('excellent')
+
+      // Reset
+      reset()
+
+      expect(isAvailable.value).toBe(false)
+      expect(indicator.value.level).toBe('unknown')
+      expect(indicator.value.bars).toBe(1)
+      expect(indicator.value.icon).toBe('signal-unknown')
+    })
+
+    it('should clear network details on reset', () => {
+      const { indicator, update, reset } = useNetworkQualityIndicator()
+
+      update({
+        rtt: 50,
+        jitter: 10,
+        packetLoss: 0.3,
+        candidateType: 'host',
+      })
+
+      reset()
+
+      expect(indicator.value.details.rtt).toBe(0)
+      expect(indicator.value.details.jitter).toBe(0)
+      expect(indicator.value.details.packetLoss).toBe(0)
+      expect(indicator.value.details.bandwidth).toBe(0)
+      expect(indicator.value.details.connectionType).toBe('unknown')
+    })
+  })
+
+  // ==========================================================================
+  // Custom Thresholds
+  // ==========================================================================
+
+  describe('Custom Thresholds', () => {
+    it('should use custom RTT thresholds', () => {
+      const { indicator, update } = useNetworkQualityIndicator({
+        thresholds: {
+          rtt: [30, 60, 120, 240] as [number, number, number, number],
+        },
+      })
+
+      // 40ms would be excellent with default (50ms), but good with custom (30ms)
+      update({ rtt: 40, jitter: 5, packetLoss: 0.1 })
+
+      expect(indicator.value.level).toBe('good')
+    })
+
+    it('should use custom packet loss thresholds', () => {
+      const { indicator, update } = useNetworkQualityIndicator({
+        thresholds: {
+          packetLoss: [0.1, 0.5, 1, 2] as [number, number, number, number],
+        },
+      })
+
+      // 0.3% would be excellent with default (0.5%), but good with custom (0.1%)
+      update({ rtt: 30, jitter: 5, packetLoss: 0.3 })
+
+      expect(indicator.value.level).toBe('good')
+    })
+
+    it('should use custom jitter thresholds', () => {
+      const { indicator, update } = useNetworkQualityIndicator({
+        thresholds: {
+          jitter: [5, 10, 20, 40] as [number, number, number, number],
+        },
+      })
+
+      // 8ms would be excellent with default (10ms), but good with custom (5ms)
+      update({ rtt: 30, jitter: 8, packetLoss: 0.1 })
+
+      expect(indicator.value.level).toBe('good')
+    })
+
+    it('should merge custom thresholds with defaults', () => {
+      const { indicator, update } = useNetworkQualityIndicator({
+        thresholds: {
+          rtt: [25, 50, 100, 200] as [number, number, number, number],
+          // jitter and packetLoss use defaults
+        },
+      })
+
+      // Test that RTT uses custom, but packet loss uses default
+      update({ rtt: 30, jitter: 5, packetLoss: 0.4 })
+
+      // RTT 30 with custom threshold (25) = good
+      // Packet loss 0.4 with default threshold (0.5) = excellent
+      // Worst is good
+      expect(indicator.value.level).toBe('good')
+    })
+  })
+
+  // ==========================================================================
+  // Edge Cases
+  // ==========================================================================
+
+  describe('Edge Cases', () => {
+    it('should handle zero values', () => {
+      const { indicator, update } = useNetworkQualityIndicator()
+
+      update({
+        rtt: 0,
+        jitter: 0,
+        packetLoss: 0,
+      })
+
+      expect(indicator.value.level).toBe('excellent')
+    })
+
+    it('should handle very high values', () => {
+      const { indicator, update } = useNetworkQualityIndicator()
+
+      update({
+        rtt: 10000,
+        jitter: 500,
+        packetLoss: 50,
+      })
+
+      expect(indicator.value.level).toBe('critical')
+    })
+
+    it('should handle negative values as zero', () => {
+      const { indicator, update } = useNetworkQualityIndicator()
+
+      update({
+        rtt: -10,
+        jitter: -5,
+        packetLoss: -1,
+      })
+
+      // Negative values should be treated as 0 (excellent)
+      expect(indicator.value.level).toBe('excellent')
+    })
+
+    it('should handle undefined individual metrics in update', () => {
+      const { indicator, update } = useNetworkQualityIndicator()
+
+      update({
+        rtt: 50,
+        jitter: undefined,
+        packetLoss: 0.3,
+      })
+
+      expect(indicator.value.level).not.toBe('unknown')
+      expect(indicator.value.details.rtt).toBe(50)
+    })
+
+    it('should handle rapid consecutive updates', () => {
+      const { indicator, update } = useNetworkQualityIndicator()
+
+      // Rapid updates
+      for (let i = 0; i < 100; i++) {
+        update({ rtt: 50 + i, jitter: 10, packetLoss: 0.3 })
+      }
+
+      // Should have the last update's RTT
+      expect(indicator.value.details.rtt).toBe(149)
+    })
+  })
+
+  // ==========================================================================
+  // Connection Type Handling
+  // ==========================================================================
+
+  describe('Connection Type', () => {
+    it('should store host connection type', () => {
+      const { indicator, update } = useNetworkQualityIndicator()
+
+      update({ rtt: 50, candidateType: 'host' })
+
+      expect(indicator.value.details.connectionType).toBe('host')
+    })
+
+    it('should store relay connection type', () => {
+      const { indicator, update } = useNetworkQualityIndicator()
+
+      update({ rtt: 50, candidateType: 'relay' })
+
+      expect(indicator.value.details.connectionType).toBe('relay')
+    })
+
+    it('should store srflx connection type', () => {
+      const { indicator, update } = useNetworkQualityIndicator()
+
+      update({ rtt: 50, candidateType: 'srflx' })
+
+      expect(indicator.value.details.connectionType).toBe('srflx')
+    })
+
+    it('should store prflx connection type', () => {
+      const { indicator, update } = useNetworkQualityIndicator()
+
+      update({ rtt: 50, candidateType: 'prflx' })
+
+      expect(indicator.value.details.connectionType).toBe('prflx')
+    })
+  })
+
+  // ==========================================================================
+  // Bandwidth Estimation Option
+  // ==========================================================================
+
+  describe('Bandwidth Estimation', () => {
+    it('should disable bandwidth estimation when option is false', () => {
+      const { indicator, update } = useNetworkQualityIndicator({
+        estimateBandwidth: false,
+      })
+
+      update({
+        rtt: 50,
+        bitrate: 2000,
+      })
+
+      // Bandwidth should be 0 when estimation is disabled
+      expect(indicator.value.details.bandwidth).toBe(0)
+    })
+
+    it('should estimate bandwidth by default', () => {
+      const { indicator, update } = useNetworkQualityIndicator()
+
+      update({
+        rtt: 50,
+        bitrate: 2000,
+      })
+
+      // Bandwidth should be estimated from bitrate
+      expect(indicator.value.details.bandwidth).toBeGreaterThan(0)
+    })
+
+    it('should prefer availableOutgoingBitrate over bitrate for bandwidth', () => {
+      const { indicator, update } = useNetworkQualityIndicator()
+
+      update({
+        rtt: 50,
+        bitrate: 1000,
+        availableOutgoingBitrate: 3000,
+      })
+
+      expect(indicator.value.details.bandwidth).toBe(3000)
+    })
+  })
+
+  // ==========================================================================
+  // Reactive Updates
+  // ==========================================================================
+
+  describe('Reactivity', () => {
+    it('should trigger reactive updates on update()', () => {
+      const { indicator, update } = useNetworkQualityIndicator()
+
+      const levels: string[] = []
+
+      // Manually track changes
+      update({ rtt: 20, jitter: 5, packetLoss: 0.1 })
+      levels.push(indicator.value.level)
+
+      update({ rtt: 500, jitter: 100, packetLoss: 10 })
+      levels.push(indicator.value.level)
+
+      expect(levels).toEqual(['excellent', 'critical'])
+    })
+
+    it('should update all indicator properties atomically', () => {
+      const { indicator, update } = useNetworkQualityIndicator()
+
+      update({ rtt: 20, jitter: 5, packetLoss: 0.1 })
+
+      // All properties should be consistent with excellent quality
+      expect(indicator.value.level).toBe('excellent')
+      expect(indicator.value.bars).toBe(5)
+      expect(indicator.value.icon).toBe('signal-excellent')
+      expect(indicator.value.color).toBe(DEFAULT_NETWORK_COLORS.excellent)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Add `useCallQualityScore` composable: Combines multiple WebRTC metrics into a unified quality score with grade (A-F), trend analysis, and historical tracking
- Add `useNetworkQualityIndicator` composable: Provides reactive network quality indicators including signal bars (1-5), quality levels, colors, and accessibility labels
- Add `useBandwidthAdaptation` composable: Intelligent bandwidth adaptation recommendations for resolution, framerate, and bitrate adjustments based on network conditions
- Add comprehensive TypeScript types in `call-quality.types.ts`
- Export all composables, types, and constants from `composables/index.ts`

## Test plan
- [x] All 163 new tests pass (`useCallQualityScore`: 50, `useNetworkQualityIndicator`: 59, `useBandwidthAdaptation`: 54)
- [x] Full test suite passes (4,687 tests)
- [x] TypeScript typecheck passes
- [x] ESLint passes (0 errors, warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)