### PR TITLE
fix: use --no-frozen-lockfile for template deployments

### DIFF
--- a/.github/workflows/deploy-templates.yml
+++ b/.github/workflows/deploy-templates.yml
@@ -86,7 +86,7 @@ jobs:
         run: |
           # Replace workspace link with local path for deployment
           sed -i 's/"vuesip": "workspace:\*"/"vuesip": "file:..\/..\/dist"/' package.json
-          pnpm install
+          pnpm install --no-frozen-lockfile
 
       - name: Build template
         working-directory: templates/minimal
@@ -132,7 +132,7 @@ jobs:
         run: |
           # Replace workspace link with local path for deployment
           sed -i 's/"vuesip": "workspace:\*"/"vuesip": "file:..\/..\/dist"/' package.json
-          pnpm install
+          pnpm install --no-frozen-lockfile
 
       - name: Build template
         working-directory: templates/basic-softphone
@@ -178,7 +178,7 @@ jobs:
         run: |
           # Replace workspace link with local path for deployment
           sed -i 's/"vuesip": "workspace:\*"/"vuesip": "file:..\/..\/dist"/' package.json
-          pnpm install
+          pnpm install --no-frozen-lockfile
 
       - name: Build template
         working-directory: templates/call-center


### PR DESCRIPTION
## Summary
- Fix template deployment workflow failure
- The workflow modifies package.json to replace `workspace:*` with `file:../../dist`
- This causes pnpm's frozen-lockfile check to fail in CI
- Adding `--no-frozen-lockfile` allows the install to proceed

## Root Cause
pnpm in CI defaults to `--frozen-lockfile`, which validates package.json matches the lockfile. Since we dynamically modify the vuesip dependency, this validation fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)