### PR TITLE
fix: create package.json in dist for template builds

### DIFF
--- a/.github/workflows/deploy-templates.yml
+++ b/.github/workflows/deploy-templates.yml
@@ -47,6 +47,27 @@ jobs:
       - name: Build library
         run: pnpm run build
 
+      - name: Create dist package.json
+        run: |
+          # Create a package.json in dist with correct exports for file: dependency
+          cat > dist/package.json << 'EOF'
+          {
+            "name": "vuesip",
+            "version": "1.0.0",
+            "type": "module",
+            "main": "./vuesip.cjs",
+            "module": "./vuesip.js",
+            "types": "./index.d.ts",
+            "exports": {
+              ".": {
+                "types": "./index.d.ts",
+                "import": "./vuesip.js",
+                "require": "./vuesip.cjs"
+              }
+            }
+          }
+          EOF
+
       - name: Upload library artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- Fix template deployment build failures
- The templates use `file:../../dist` to reference the built library
- But the dist folder needs a package.json with proper exports for Vite/Rollup to resolve the `vuesip` import correctly

## Root Cause
When using `file:` protocol, npm/pnpm expects a valid package with package.json. The dist folder only had the built JS files without package.json, causing Rollup to fail with 'failed to resolve import vuesip'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)