### PR TITLE
fix: switch from Cloudflare Workers to Pages for custom domain support

### DIFF
--- a/.github/workflows/deploy-templates.yml
+++ b/.github/workflows/deploy-templates.yml
@@ -113,13 +113,12 @@ jobs:
         working-directory: templates/minimal
         run: pnpm run build
 
-      - name: Deploy to Cloudflare Workers
+      - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          workingDirectory: templates/minimal
-          command: deploy
+          command: pages deploy templates/minimal/dist --project-name=vuesip-minimal
 
   deploy-softphone:
     name: Deploy Basic Softphone Template
@@ -159,13 +158,12 @@ jobs:
         working-directory: templates/basic-softphone
         run: pnpm run build
 
-      - name: Deploy to Cloudflare Workers
+      - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          workingDirectory: templates/basic-softphone
-          command: deploy
+          command: pages deploy templates/basic-softphone/dist --project-name=vuesip-softphone
 
   deploy-callcenter:
     name: Deploy Call Center Template
@@ -205,10 +203,9 @@ jobs:
         working-directory: templates/call-center
         run: pnpm run build
 
-      - name: Deploy to Cloudflare Workers
+      - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          workingDirectory: templates/call-center
-          command: deploy
+          command: pages deploy templates/call-center/dist --project-name=vuesip-callcenter


### PR DESCRIPTION
## Summary
- Switch template deployments from Cloudflare Workers to Cloudflare Pages
- Workers with static assets don't support custom domains
- Pages is designed for static sites and supports custom domains natively

## Changes
- Updated workflow to use `wrangler pages deploy` instead of `wrangler deploy`
- Project names: vuesip-minimal, vuesip-softphone, vuesip-callcenter

## After Merge
You'll need to add custom domains in Cloudflare Dashboard:
1. Go to **Workers & Pages** → Select the Pages project
2. Click **Custom domains** → **Set up a custom domain**
3. Add: minimal.vuesip.com, softphone.vuesip.com, callcenter.vuesip.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)