### PR TITLE
fix: add production branch and commit-dirty flags for Pages deployment

### DIFF
--- a/.github/workflows/deploy-templates.yml
+++ b/.github/workflows/deploy-templates.yml
@@ -118,7 +118,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy templates/minimal/dist --project-name=vuesip-minimal
+          command: pages deploy templates/minimal/dist --project-name=vuesip-minimal --branch=main --commit-dirty=true
 
   deploy-softphone:
     name: Deploy Basic Softphone Template
@@ -163,7 +163,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy templates/basic-softphone/dist --project-name=vuesip-softphone
+          command: pages deploy templates/basic-softphone/dist --project-name=vuesip-softphone --branch=main --commit-dirty=true
 
   deploy-callcenter:
     name: Deploy Call Center Template
@@ -208,4 +208,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy templates/call-center/dist --project-name=vuesip-callcenter
+          command: pages deploy templates/call-center/dist --project-name=vuesip-callcenter --branch=main --commit-dirty=true


### PR DESCRIPTION
## Summary
- Adds `--branch=main` to specify production branch for Pages deployments
- Adds `--commit-dirty=true` to allow deployment in CI environment

The previous deployment failed with "Project not found" error because the Pages projects (vuesip-minimal, vuesip-softphone, vuesip-callcenter) don't exist yet in Cloudflare. These flags should help wrangler auto-create the projects on first deployment.

## Test plan
- [ ] Merge PR and verify deployment workflow runs successfully
- [ ] Verify Pages projects are created in Cloudflare dashboard
- [ ] Verify templates are accessible at workers.dev URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)