### PR TITLE
fix: create Pages projects before deployment

### DIFF
--- a/.github/workflows/deploy-templates.yml
+++ b/.github/workflows/deploy-templates.yml
@@ -113,6 +113,14 @@ jobs:
         working-directory: templates/minimal
         run: pnpm run build
 
+      - name: Create Pages project (if not exists)
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages project create vuesip-minimal --production-branch=main
+        continue-on-error: true
+
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3
         with:
@@ -158,6 +166,14 @@ jobs:
         working-directory: templates/basic-softphone
         run: pnpm run build
 
+      - name: Create Pages project (if not exists)
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages project create vuesip-softphone --production-branch=main
+        continue-on-error: true
+
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3
         with:
@@ -202,6 +218,14 @@ jobs:
       - name: Build template
         working-directory: templates/call-center
         run: pnpm run build
+
+      - name: Create Pages project (if not exists)
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages project create vuesip-callcenter --production-branch=main
+        continue-on-error: true
 
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3


### PR DESCRIPTION
## Summary
- Adds a step to create each Cloudflare Pages project before deploying
- Uses `continue-on-error: true` so the step succeeds even if the project already exists

The `wrangler pages deploy` command doesn't auto-create projects - they must exist first. This fix adds `wrangler pages project create` before each deployment.

## Test plan
- [ ] Merge and verify deployment creates the Pages projects
- [ ] Templates should be accessible at:
  - `vuesip-minimal.pages.dev`
  - `vuesip-softphone.pages.dev`  
  - `vuesip-callcenter.pages.dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)