### PR TITLE
feat(e2e): enable network-conditions E2E tests with NetworkSimulator

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -36,7 +36,7 @@ const GLOBAL_TEST_IGNORE = [
   // Infrastructure requirements - need additional mock capabilities
   /audio-devices\.spec\.ts/, // Requires mock media device integration
   /multi-user\.spec\.ts/, // Requires multi-instance mock coordination
-  /network-conditions\.spec\.ts/, // Requires network simulation
+  // network-conditions.spec.ts - ENABLED: NetworkSimulator implemented in MockSipServer.ts
 
   // CI-specific issues - pass locally but fail in CI
   /accessibility\.spec\.ts/, // CI timing issues with axe-core (24 tests pass locally)


### PR DESCRIPTION
## Summary
- Implements WebSocket-level network simulation in MockSipServer
- Enables the previously skipped 18 network-conditions E2E tests
- Adds NetworkSimulator with configurable latency, jitter, packet loss, and offline mode

## Changes
- **MockSipServer.ts**: Add `NetworkSimulator` singleton with:
  - Configurable latency with jitter
  - Packet loss simulation
  - Offline mode simulation
  - Network presets (FAST_4G, SLOW_3G, EDGE_2G, CROWDED, LOSSY_NETWORK, OFFLINE)
  - Integration with MockSipWebSocket for realistic network behavior

- **network-conditions.spec.ts**: Update tests to use NetworkSimulator:
  - Replace Playwright's `context.route()` with `NetworkSimulator.setPreset()`
  - Replace `context.setOffline()` with `NetworkSimulator.setOffline()`
  - Add `NetworkSimulator.reset()` in beforeEach/afterEach for test isolation
  - Fix test assertions for improved reliability

- **playwright.config.ts**: Remove network-conditions.spec.ts from ignore list

## Test plan
- [x] All 18 network-conditions E2E tests pass locally (chromium)
- [x] Existing unit tests still pass (5447 tests)
- [ ] CI passes on all browsers

🤖 Generated with [Claude Code](https://claude.com/claude-code)