### PR TITLE
docs: add examples sidebar navigation with 28 example pages

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -129,6 +129,88 @@ export default defineConfig({
           text: 'Examples',
           items: [{ text: 'Overview', link: '/examples/' }],
         },
+        {
+          text: 'Getting Started',
+          collapsed: false,
+          items: [
+            { text: 'Quick Start', link: '/examples/quick-start' },
+            { text: 'Learning Paths', link: '/examples/learning-paths' },
+          ],
+        },
+        {
+          text: 'Core Calling',
+          collapsed: false,
+          items: [
+            { text: 'Basic Audio Call', link: '/examples/basic-call' },
+            { text: 'Video Calling', link: '/examples/video-call' },
+            { text: 'Conference Calls', link: '/examples/conference' },
+            { text: 'Call Transfer', link: '/examples/call-transfer' },
+            { text: 'Multi-Line', link: '/examples/multi-line' },
+          ],
+        },
+        {
+          text: 'Call Controls',
+          collapsed: false,
+          items: [
+            { text: 'DTMF Tones', link: '/examples/dtmf' },
+            { text: 'Hold & Mute', link: '/examples/hold-mute' },
+            { text: 'Call Timer', link: '/examples/call-timer' },
+            { text: 'Auto Answer', link: '/examples/auto-answer' },
+          ],
+        },
+        {
+          text: 'Call Quality',
+          collapsed: false,
+          items: [
+            { text: 'Quality Monitoring', link: '/examples/call-quality' },
+            { text: 'Connection Recovery', link: '/examples/connection-recovery' },
+          ],
+        },
+        {
+          text: 'Transcription',
+          collapsed: false,
+          items: [
+            { text: 'Real-Time Transcription', link: '/examples/transcription' },
+            { text: 'Keyword Detection', link: '/examples/transcription-keywords' },
+          ],
+        },
+        {
+          text: 'Video & Recording',
+          collapsed: false,
+          items: [
+            { text: 'Picture-in-Picture', link: '/examples/picture-in-picture' },
+            { text: 'Screen Sharing', link: '/examples/screen-sharing' },
+            { text: 'Call Recording', link: '/examples/call-recording' },
+            { text: 'Conference Gallery', link: '/examples/conference-gallery' },
+          ],
+        },
+        {
+          text: 'Communication',
+          collapsed: false,
+          items: [
+            { text: 'Presence & BLF', link: '/examples/presence' },
+            { text: 'SIP Messaging', link: '/examples/sip-messaging' },
+            { text: 'Voicemail', link: '/examples/voicemail' },
+          ],
+        },
+        {
+          text: 'Call Center (AMI)',
+          collapsed: true,
+          items: [
+            { text: 'Agent Login', link: '/examples/agent-login' },
+            { text: 'Queue Monitor', link: '/examples/queue-monitor' },
+            { text: 'CDR Dashboard', link: '/examples/cdr-dashboard' },
+          ],
+        },
+        {
+          text: 'Settings & Utilities',
+          collapsed: true,
+          items: [
+            { text: 'Audio Devices', link: '/examples/audio-devices' },
+            { text: 'Call History', link: '/examples/call-history' },
+            { text: 'Settings Persistence', link: '/examples/settings' },
+          ],
+        },
       ],
 
       '/developer/': [

--- a/docs/examples/agent-login.md
+++ b/docs/examples/agent-login.md
@@ -1,0 +1,63 @@
+# Agent Login
+
+Call center agent authentication and status management.
+
+::: tip Try It Live
+Run `pnpm dev` → Navigate to **AgentLoginDemo** in the playground
+:::
+
+## Overview
+
+Agent login features:
+
+- Agent login/logout
+- Queue membership management
+- Break/pause status
+- Extension assignment
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useAmiAgentLogin } from 'vuesip'
+
+const { isLoggedIn, agentStatus, login, logout, pause, unpause, queues } = useAmiAgentLogin()
+
+const agentId = ref('')
+const extension = ref('')
+</script>
+
+<template>
+  <div class="agent-login-demo">
+    <div v-if="!isLoggedIn" class="login-form">
+      <input v-model="agentId" placeholder="Agent ID" />
+      <input v-model="extension" placeholder="Extension" />
+      <button @click="login(agentId, extension)">Login</button>
+    </div>
+
+    <div v-else class="agent-panel">
+      <p>Status: {{ agentStatus }}</p>
+      <p>Queues: {{ queues.join(', ') }}</p>
+
+      <button v-if="agentStatus === 'available'" @click="pause('Break')">Take Break</button>
+      <button v-else @click="unpause()">Return from Break</button>
+
+      <button @click="logout">Logout</button>
+    </div>
+  </div>
+</template>
+```
+
+## Key Composables
+
+| Composable         | Purpose              |
+| ------------------ | -------------------- |
+| `useAmiAgentLogin` | Agent authentication |
+| `useAmiAgentStats` | Agent statistics     |
+
+## Related
+
+- [Queue Monitor](/examples/queue-monitor)
+- [CDR Dashboard](/examples/cdr-dashboard)
+- [AMI Guide](/guide/ami-cdr)

--- a/docs/examples/audio-devices.md
+++ b/docs/examples/audio-devices.md
@@ -1,0 +1,181 @@
+# Audio Devices
+
+Complete audio device management with microphone and speaker selection.
+
+::: tip Try It Live
+Run `pnpm dev` → Navigate to **AudioDevicesDemo** in the playground
+:::
+
+## Overview
+
+Audio device management includes:
+
+- Microphone enumeration and selection
+- Speaker/output device selection
+- Volume controls
+- Device change detection
+- Permission handling
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { useMediaDevices, useAudioDevices } from 'vuesip'
+
+const {
+  audioInputDevices,
+  audioOutputDevices,
+  selectedAudioInput,
+  selectedAudioOutput,
+  selectAudioInput,
+  selectAudioOutput,
+  requestPermissions,
+  hasPermission,
+} = useMediaDevices()
+
+const { inputVolume, outputVolume, setInputVolume, setOutputVolume, inputLevel, testAudio } =
+  useAudioDevices()
+
+// Request microphone permission on mount
+onMounted(async () => {
+  await requestPermissions(true, false) // audio only
+})
+</script>
+
+<template>
+  <div class="audio-demo">
+    <!-- Permission Request -->
+    <div v-if="!hasPermission" class="permission-prompt">
+      <p>Microphone access is required</p>
+      <button @click="requestPermissions(true, false)">Grant Permission</button>
+    </div>
+
+    <template v-else>
+      <!-- Microphone Selection -->
+      <div class="device-section">
+        <label>Microphone</label>
+        <select
+          :value="selectedAudioInput?.deviceId"
+          @change="selectAudioInput($event.target.value)"
+        >
+          <option
+            v-for="device in audioInputDevices"
+            :key="device.deviceId"
+            :value="device.deviceId"
+          >
+            {{ device.label }}
+          </option>
+        </select>
+
+        <!-- Input Level Meter -->
+        <div class="level-meter">
+          <div class="level-bar" :style="{ width: `${inputLevel * 100}%` }" />
+        </div>
+
+        <!-- Input Volume -->
+        <input
+          type="range"
+          :value="inputVolume"
+          @input="setInputVolume(Number($event.target.value))"
+          min="0"
+          max="1"
+          step="0.1"
+        />
+      </div>
+
+      <!-- Speaker Selection -->
+      <div class="device-section">
+        <label>Speaker</label>
+        <select
+          :value="selectedAudioOutput?.deviceId"
+          @change="selectAudioOutput($event.target.value)"
+        >
+          <option
+            v-for="device in audioOutputDevices"
+            :key="device.deviceId"
+            :value="device.deviceId"
+          >
+            {{ device.label }}
+          </option>
+        </select>
+
+        <!-- Output Volume -->
+        <input
+          type="range"
+          :value="outputVolume"
+          @input="setOutputVolume(Number($event.target.value))"
+          min="0"
+          max="1"
+          step="0.1"
+        />
+
+        <!-- Test Audio -->
+        <button @click="testAudio">Test Speaker</button>
+      </div>
+    </template>
+  </div>
+</template>
+```
+
+## Features
+
+- **Device Enumeration**: List all available audio devices
+- **Device Selection**: Choose input and output devices
+- **Volume Control**: Adjust input/output levels
+- **Level Metering**: Visual audio input indicator
+- **Test Audio**: Play test sound through selected speaker
+- **Hot-Swap**: Change devices during active calls
+- **Permission Handling**: Request and check microphone permissions
+
+## Key Composables
+
+| Composable        | Purpose                          |
+| ----------------- | -------------------------------- |
+| `useMediaDevices` | Device enumeration and selection |
+| `useAudioDevices` | Volume control and audio testing |
+
+## Device Change Detection
+
+```typescript
+const { audioInputDevices, onDeviceChange } = useMediaDevices()
+
+// Listen for device changes (plug/unplug)
+onDeviceChange((devices) => {
+  console.log('Devices changed:', devices)
+  // Re-select default if current device was removed
+})
+```
+
+## Permission Handling
+
+```typescript
+const { hasPermission, permissionState, requestPermissions } = useMediaDevices()
+
+// Check permission state
+// 'granted' | 'denied' | 'prompt'
+
+// Request with specific media types
+await requestPermissions(
+  true, // audio
+  false // video
+)
+```
+
+## Change Device During Call
+
+```typescript
+const { currentCall } = useCallSession()
+const { selectAudioInput } = useMediaDevices()
+
+async function switchMicrophone(deviceId: string) {
+  await selectAudioInput(deviceId)
+  // Device change is automatically applied to active call
+}
+```
+
+## Related
+
+- [Basic Call](/examples/basic-call)
+- [Video Calling](/examples/video-call)
+- [Settings Persistence](/examples/settings)
+- [Device Management Guide](/guide/device-management)

--- a/docs/examples/auto-answer.md
+++ b/docs/examples/auto-answer.md
@@ -1,0 +1,57 @@
+# Auto Answer
+
+Automatic call answering based on configurable rules.
+
+::: tip Try It Live
+Run `pnpm dev` → Navigate to **AutoAnswerDemo** in the playground
+:::
+
+## Overview
+
+Auto-answer capabilities:
+
+- Enable/disable auto-answer
+- Configurable delay before answering
+- Caller ID filtering
+- Queue call handling
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { useSipAutoAnswer } from 'vuesip'
+
+const { isEnabled, enable, disable, setDelay, delay, addAllowedCaller } = useSipAutoAnswer({
+  enabled: false,
+  delayMs: 2000,
+  allowedCallers: [],
+})
+</script>
+
+<template>
+  <div class="auto-answer-demo">
+    <label>
+      <input type="checkbox" :checked="isEnabled" @change="isEnabled ? disable() : enable()" />
+      Auto-Answer Enabled
+    </label>
+
+    <div v-if="isEnabled">
+      <label>
+        Delay (ms):
+        <input type="number" :value="delay" @input="setDelay(Number($event.target.value))" />
+      </label>
+    </div>
+  </div>
+</template>
+```
+
+## Key Composables
+
+| Composable         | Purpose                   |
+| ------------------ | ------------------------- |
+| `useSipAutoAnswer` | Auto-answer configuration |
+
+## Related
+
+- [Basic Call](/examples/basic-call)
+- [Agent Login](/examples/agent-login)

--- a/docs/examples/basic-call.md
+++ b/docs/examples/basic-call.md
@@ -1,0 +1,154 @@
+# Basic Audio Call
+
+A complete example of one-to-one audio calling with connection management.
+
+::: tip Try It Live
+Run `pnpm dev` → Navigate to **BasicCallDemo** in the playground
+:::
+
+## Overview
+
+The basic call demo shows how to:
+
+- Connect to a SIP server
+- Register your extension
+- Make outbound calls
+- Receive incoming calls
+- Track call state and duration
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import { useSipClient, useCallSession } from 'vuesip'
+
+// SIP connection
+const { connect, disconnect, isConnected, isRegistered, error } = useSipClient()
+
+// Call management
+const { currentCall, makeCall, answer, hangup, callDuration } = useCallSession()
+
+// Form state
+const credentials = ref({
+  uri: 'sip:1000@example.com',
+  password: '',
+  server: 'wss://sip.example.com:8089/ws',
+})
+const targetNumber = ref('')
+
+// Computed
+const callState = computed(() => currentCall.value?.state ?? 'idle')
+const isInCall = computed(() => ['ringing', 'answered', 'connecting'].includes(callState.value))
+
+// Actions
+async function handleConnect() {
+  await connect(credentials.value)
+}
+
+async function handleCall() {
+  if (targetNumber.value && isRegistered.value) {
+    await makeCall(targetNumber.value)
+  }
+}
+
+function formatDuration(seconds: number): string {
+  const mins = Math.floor(seconds / 60)
+  const secs = seconds % 60
+  return `${mins}:${secs.toString().padStart(2, '0')}`
+}
+</script>
+
+<template>
+  <div class="call-demo">
+    <!-- Connection Form -->
+    <section v-if="!isConnected" class="connection-form">
+      <h3>Connect to SIP Server</h3>
+      <input v-model="credentials.uri" placeholder="SIP URI (sip:1000@example.com)" />
+      <input v-model="credentials.password" type="password" placeholder="Password" />
+      <input v-model="credentials.server" placeholder="WebSocket Server" />
+      <button @click="handleConnect">Connect</button>
+      <p v-if="error" class="error">{{ error.message }}</p>
+    </section>
+
+    <!-- Connected State -->
+    <section v-else class="call-interface">
+      <div class="status">
+        <span class="indicator" :class="{ active: isRegistered }"></span>
+        {{ isRegistered ? 'Registered' : 'Connecting...' }}
+      </div>
+
+      <!-- Dialpad -->
+      <div v-if="!isInCall" class="dialpad">
+        <input
+          v-model="targetNumber"
+          placeholder="Enter number to call"
+          @keyup.enter="handleCall"
+        />
+        <button @click="handleCall" :disabled="!targetNumber || !isRegistered">Call</button>
+      </div>
+
+      <!-- Active Call -->
+      <div v-else class="active-call">
+        <p class="call-status">{{ callState }}</p>
+        <p class="duration">{{ formatDuration(callDuration) }}</p>
+
+        <div class="call-actions">
+          <button v-if="callState === 'ringing'" @click="answer" class="answer">Answer</button>
+          <button @click="hangup" class="hangup">Hang Up</button>
+        </div>
+      </div>
+
+      <button @click="disconnect" class="disconnect">Disconnect</button>
+    </section>
+  </div>
+</template>
+```
+
+## Features
+
+- **SIP Client Connection**: WebSocket-based SIP connection with TLS
+- **Registration**: Automatic SIP REGISTER with configurable expiry
+- **Outbound Calls**: Make calls to any SIP URI or phone number
+- **Inbound Calls**: Receive and answer incoming calls
+- **Call State Tracking**: Real-time call state updates
+- **Duration Display**: Live call timer with formatted output
+- **Error Handling**: Comprehensive error feedback
+
+## Key Composables
+
+| Composable       | Purpose                                          |
+| ---------------- | ------------------------------------------------ |
+| `useSipClient`   | Connection, registration, and session management |
+| `useCallSession` | Call lifecycle, state, and actions               |
+
+## Call States
+
+| State        | Description                          |
+| ------------ | ------------------------------------ |
+| `idle`       | No active call                       |
+| `connecting` | Outbound call being established      |
+| `ringing`    | Incoming call waiting to be answered |
+| `answered`   | Call is active                       |
+| `ended`      | Call has terminated                  |
+
+## Error Handling
+
+```typescript
+const { error } = useSipClient()
+
+watch(error, (newError) => {
+  if (newError) {
+    console.error('SIP Error:', newError.code, newError.message)
+    // Show user-friendly error message
+  }
+})
+```
+
+## Related
+
+- [Quick Start](/examples/quick-start)
+- [Video Calling](/examples/video-call)
+- [Call Controls Guide](/guide/call-controls)
+- [API: useSipClient](/api/composables#usesipclient)
+- [API: useCallSession](/api/composables#usecallsession)

--- a/docs/examples/call-history.md
+++ b/docs/examples/call-history.md
@@ -1,0 +1,213 @@
+# Call History
+
+Call log management with search, filtering, and callback functionality.
+
+::: tip Try It Live
+Run `pnpm dev` → Navigate to **CallHistoryDemo** in the playground
+:::
+
+## Overview
+
+Call history features include:
+
+- Incoming, outgoing, and missed call logs
+- Date range filtering
+- Search by number or name
+- Call back functionality
+- Persistent storage
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import { useCallHistory, useCallSession } from 'vuesip'
+
+const { makeCall } = useCallSession()
+
+const {
+  history,
+  filteredHistory,
+  addEntry,
+  removeEntry,
+  clearHistory,
+  searchQuery,
+  filterType,
+  setFilter,
+  setSearch,
+} = useCallHistory()
+
+// Filter options
+const filterOptions = [
+  { value: 'all', label: 'All Calls' },
+  { value: 'incoming', label: 'Incoming' },
+  { value: 'outgoing', label: 'Outgoing' },
+  { value: 'missed', label: 'Missed' },
+]
+
+function callBack(entry) {
+  makeCall(entry.number)
+}
+
+function formatDuration(seconds: number): string {
+  if (!seconds) return '--'
+  const mins = Math.floor(seconds / 60)
+  const secs = seconds % 60
+  return `${mins}:${secs.toString().padStart(2, '0')}`
+}
+
+function formatDate(timestamp: number): string {
+  return new Date(timestamp).toLocaleString()
+}
+</script>
+
+<template>
+  <div class="history-demo">
+    <!-- Filters -->
+    <div class="filters">
+      <input
+        :value="searchQuery"
+        @input="setSearch($event.target.value)"
+        placeholder="Search calls..."
+      />
+
+      <select :value="filterType" @change="setFilter($event.target.value)">
+        <option v-for="opt in filterOptions" :key="opt.value" :value="opt.value">
+          {{ opt.label }}
+        </option>
+      </select>
+
+      <button @click="clearHistory" class="clear-btn">Clear All</button>
+    </div>
+
+    <!-- Call List -->
+    <div class="call-list">
+      <div v-for="entry in filteredHistory" :key="entry.id" :class="['call-entry', entry.type]">
+        <div class="call-icon">
+          <span v-if="entry.type === 'incoming'">📥</span>
+          <span v-else-if="entry.type === 'outgoing'">📤</span>
+          <span v-else>📵</span>
+        </div>
+
+        <div class="call-info">
+          <span class="number">{{ entry.displayName || entry.number }}</span>
+          <span class="date">{{ formatDate(entry.timestamp) }}</span>
+        </div>
+
+        <div class="call-meta">
+          <span class="duration">{{ formatDuration(entry.duration) }}</span>
+        </div>
+
+        <div class="call-actions">
+          <button @click="callBack(entry)">Call</button>
+          <button @click="removeEntry(entry.id)">Delete</button>
+        </div>
+      </div>
+
+      <div v-if="filteredHistory.length === 0" class="empty">No calls found</div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.call-entry {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 12px;
+  border-bottom: 1px solid #eee;
+}
+
+.call-entry.missed {
+  background: #fef2f2;
+}
+
+.call-entry.missed .number {
+  color: #dc2626;
+}
+</style>
+```
+
+## Features
+
+- **Call Logging**: Automatic logging of all calls
+- **Call Types**: Incoming, outgoing, missed
+- **Filtering**: Filter by call type
+- **Search**: Search by number or contact name
+- **Callback**: One-click to return a call
+- **Persistence**: Stored in localStorage
+- **Date Range**: Filter by time period
+
+## Key Composables
+
+| Composable       | Purpose                    |
+| ---------------- | -------------------------- |
+| `useCallHistory` | Call log management        |
+| `useCallSession` | For callback functionality |
+
+## Call Entry Structure
+
+```typescript
+interface CallHistoryEntry {
+  id: string
+  number: string
+  displayName?: string
+  type: 'incoming' | 'outgoing' | 'missed'
+  timestamp: number // Unix timestamp
+  duration: number // Seconds
+  answered: boolean
+}
+```
+
+## Filtering API
+
+```typescript
+const {
+  filterType, // Ref<'all' | 'incoming' | 'outgoing' | 'missed'>
+  searchQuery, // Ref<string>
+  dateRange, // Ref<{ start: Date, end: Date } | null>
+
+  setFilter, // (type: FilterType) => void
+  setSearch, // (query: string) => void
+  setDateRange, // (range: DateRange | null) => void
+} = useCallHistory()
+```
+
+## Manual Entry Management
+
+```typescript
+const { addEntry, removeEntry, clearHistory } = useCallHistory()
+
+// Add a call manually
+addEntry({
+  number: '+1234567890',
+  displayName: 'John Doe',
+  type: 'incoming',
+  timestamp: Date.now(),
+  duration: 180,
+  answered: true,
+})
+
+// Remove specific entry
+removeEntry('entry-id')
+
+// Clear all history
+clearHistory()
+```
+
+## Storage Configuration
+
+```typescript
+const history = useCallHistory({
+  storageKey: 'vuesip-call-history',
+  maxEntries: 100, // Maximum stored entries
+  persistOnUnload: true, // Save before page unload
+})
+```
+
+## Related
+
+- [Basic Call](/examples/basic-call)
+- [Settings Persistence](/examples/settings)
+- [Call History Guide](/guide/call-history)
+- [API: useCallHistory](/api/composables#usecallhistory)

--- a/docs/examples/call-quality.md
+++ b/docs/examples/call-quality.md
@@ -1,0 +1,158 @@
+# Call Quality Monitoring
+
+Real-time call quality metrics with scoring, trend analysis, and recommendations.
+
+::: tip Try It Live
+Run `pnpm dev` → Navigate to **CallQualityDemo** in the playground
+:::
+
+## Overview
+
+Monitor call quality in real-time with:
+
+- Quality scores (A-F grades, 0-100 scale)
+- Jitter, latency, and packet loss metrics
+- Trend analysis with confidence scoring
+- Actionable recommendations for improvement
+- Network quality indicators
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { useCallSession, useCallQualityScore, useNetworkQualityIndicator } from 'vuesip'
+
+const { currentCall } = useCallSession()
+
+const { score, grade, factors, trend, recommendations } = useCallQualityScore(currentCall)
+
+const { level, signalBars, details, colors } = useNetworkQualityIndicator(currentCall)
+</script>
+
+<template>
+  <div class="quality-demo">
+    <!-- Quality Score -->
+    <div class="score-card">
+      <div class="grade" :style="{ color: colors.text }">
+        {{ grade }}
+      </div>
+      <div class="score">{{ score }}/100</div>
+      <div class="trend" :class="trend.direction">
+        {{ trend.direction === 'improving' ? '↑' : trend.direction === 'declining' ? '↓' : '→' }}
+        {{ trend.direction }}
+      </div>
+    </div>
+
+    <!-- Signal Bars -->
+    <div class="signal-bars">
+      <div
+        v-for="i in 5"
+        :key="i"
+        class="bar"
+        :class="{ active: i <= signalBars }"
+        :style="{ backgroundColor: i <= signalBars ? colors.primary : '#ddd' }"
+      />
+    </div>
+
+    <!-- Metrics -->
+    <div class="metrics">
+      <div class="metric">
+        <span class="label">Latency</span>
+        <span class="value">{{ factors.latency?.toFixed(0) }}ms</span>
+      </div>
+      <div class="metric">
+        <span class="label">Jitter</span>
+        <span class="value">{{ factors.jitter?.toFixed(1) }}ms</span>
+      </div>
+      <div class="metric">
+        <span class="label">Packet Loss</span>
+        <span class="value">{{ (factors.packetLoss * 100)?.toFixed(2) }}%</span>
+      </div>
+    </div>
+
+    <!-- Recommendations -->
+    <div v-if="recommendations.length" class="recommendations">
+      <h4>Recommendations</h4>
+      <ul>
+        <li v-for="rec in recommendations" :key="rec">{{ rec }}</li>
+      </ul>
+    </div>
+  </div>
+</template>
+```
+
+## Features
+
+- **Quality Score**: 0-100 numeric score with letter grade
+- **Real-Time Metrics**: Latency, jitter, packet loss, MOS
+- **Trend Analysis**: Improving, stable, or declining quality
+- **Signal Indicator**: Visual 1-5 bar signal strength
+- **Recommendations**: Actionable suggestions for improvement
+- **Customizable Thresholds**: Configure quality boundaries
+
+## Key Composables
+
+| Composable                   | Purpose                            |
+| ---------------------------- | ---------------------------------- |
+| `useCallQualityScore`        | Quality scoring and trend analysis |
+| `useNetworkQualityIndicator` | Visual quality indicators          |
+| `useBandwidthAdaptation`     | Adaptive quality recommendations   |
+| `useSipWebRTCStats`          | Raw WebRTC statistics              |
+
+## Quality Grades
+
+| Grade | Score  | Description                      |
+| ----- | ------ | -------------------------------- |
+| A     | 90-100 | Excellent - Crystal clear audio  |
+| B     | 75-89  | Good - Minor imperfections       |
+| C     | 60-74  | Fair - Noticeable quality issues |
+| D     | 40-59  | Poor - Significant degradation   |
+| F     | 0-39   | Failing - Unusable quality       |
+
+## Quality Factors
+
+```typescript
+interface QualityFactors {
+  latency: number // Round-trip time in ms
+  jitter: number // Variation in packet timing
+  packetLoss: number // Percentage of lost packets (0-1)
+  mos: number // Mean Opinion Score (1-5)
+  bandwidth: number // Available bandwidth
+}
+```
+
+## Trend Analysis
+
+```typescript
+const { trend } = useCallQualityScore(call)
+
+// trend.direction: 'improving' | 'stable' | 'declining'
+// trend.confidence: 0-1 (how reliable the trend is)
+// trend.rate: Rate of change per second
+```
+
+## Custom Thresholds
+
+```typescript
+const quality = useCallQualityScore(call, {
+  weights: {
+    latency: 0.3,
+    jitter: 0.25,
+    packetLoss: 0.35,
+    mos: 0.1,
+  },
+  thresholds: {
+    excellent: { latency: 50, jitter: 10, packetLoss: 0.001 },
+    good: { latency: 100, jitter: 20, packetLoss: 0.01 },
+    fair: { latency: 200, jitter: 40, packetLoss: 0.03 },
+    poor: { latency: 400, jitter: 80, packetLoss: 0.08 },
+  },
+})
+```
+
+## Related
+
+- [Connection Recovery](/examples/connection-recovery)
+- [Call Quality Guide](/guide/call-quality)
+- [Quality Dashboard Guide](/guide/call-quality-dashboard)
+- [API: useCallQualityScore](/api/composables#usecallqualityscore)

--- a/docs/examples/call-recording.md
+++ b/docs/examples/call-recording.md
@@ -1,0 +1,56 @@
+# Call Recording
+
+Server-side call recording management.
+
+::: tip Try It Live
+Run `pnpm dev` → Navigate to **CallRecordingDemo** in the playground
+:::
+
+## Overview
+
+Recording features:
+
+- Start/stop recording
+- Recording status indicator
+- Recording file management
+- Permission handling
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { useAmiRecording, useRecordingIndicator } from 'vuesip'
+
+const { isRecording, startRecording, stopRecording, pauseRecording, resumeRecording } =
+  useAmiRecording()
+
+const { indicatorState, colors } = useRecordingIndicator()
+</script>
+
+<template>
+  <div class="recording-demo">
+    <div class="indicator" :style="{ backgroundColor: colors.background }">
+      <span class="dot" :class="{ recording: isRecording }"></span>
+      {{ indicatorState }}
+    </div>
+
+    <div class="controls">
+      <button v-if="!isRecording" @click="startRecording">Start Recording</button>
+      <button v-else @click="stopRecording">Stop Recording</button>
+    </div>
+  </div>
+</template>
+```
+
+## Key Composables
+
+| Composable              | Purpose                       |
+| ----------------------- | ----------------------------- |
+| `useAmiRecording`       | Server-side recording control |
+| `useRecordingIndicator` | Visual recording status       |
+| `useLocalRecording`     | Client-side recording         |
+
+## Related
+
+- [Basic Call](/examples/basic-call)
+- [CDR Dashboard](/examples/cdr-dashboard)

--- a/docs/examples/call-timer.md
+++ b/docs/examples/call-timer.md
@@ -1,0 +1,57 @@
+# Call Timer
+
+Real-time call duration tracking and display.
+
+::: tip Try It Live
+Run `pnpm dev` → Navigate to **CallTimerDemo** in the playground
+:::
+
+## Overview
+
+Call timer features:
+
+- Live call duration display
+- Format options (HH:MM:SS)
+- Automatic start/stop on call state changes
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useCallSession } from 'vuesip'
+
+const { currentCall, callDuration } = useCallSession()
+
+const formattedDuration = computed(() => {
+  const seconds = callDuration.value
+  const hrs = Math.floor(seconds / 3600)
+  const mins = Math.floor((seconds % 3600) / 60)
+  const secs = seconds % 60
+
+  if (hrs > 0) {
+    return `${hrs}:${mins.toString().padStart(2, '0')}:${secs.toString().padStart(2, '0')}`
+  }
+  return `${mins}:${secs.toString().padStart(2, '0')}`
+})
+</script>
+
+<template>
+  <div class="timer-demo">
+    <div class="timer" v-if="currentCall">
+      {{ formattedDuration }}
+    </div>
+  </div>
+</template>
+```
+
+## Key Composables
+
+| Composable       | Purpose                     |
+| ---------------- | --------------------------- |
+| `useCallSession` | Provides `callDuration` ref |
+
+## Related
+
+- [Basic Call](/examples/basic-call)
+- [Call History](/examples/call-history)

--- a/docs/examples/call-transfer.md
+++ b/docs/examples/call-transfer.md
@@ -1,0 +1,77 @@
+# Call Transfer
+
+Blind and attended call transfers to other extensions.
+
+::: tip Try It Live
+Run `pnpm dev` → Navigate to **CallTransferDemo** in the playground
+:::
+
+## Overview
+
+Call transfer capabilities:
+
+- Blind (cold) transfer - Transfer immediately
+- Attended (warm) transfer - Consult before transferring
+- Transfer status feedback
+- Transfer cancellation
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useCallSession, useCallTransfer } from 'vuesip'
+
+const { currentCall } = useCallSession()
+const {
+  blindTransfer,
+  attendedTransfer,
+  completeTransfer,
+  cancelTransfer,
+  transferState,
+  isTransferring,
+} = useCallTransfer(currentCall)
+
+const targetExtension = ref('')
+
+async function handleBlindTransfer() {
+  await blindTransfer(targetExtension.value)
+}
+
+async function handleAttendedTransfer() {
+  await attendedTransfer(targetExtension.value)
+}
+</script>
+
+<template>
+  <div class="transfer-demo">
+    <input v-model="targetExtension" placeholder="Transfer to..." />
+
+    <div class="transfer-buttons">
+      <button @click="handleBlindTransfer" :disabled="!targetExtension || isTransferring">
+        Blind Transfer
+      </button>
+      <button @click="handleAttendedTransfer" :disabled="!targetExtension || isTransferring">
+        Attended Transfer
+      </button>
+    </div>
+
+    <div v-if="transferState === 'consulting'" class="consulting">
+      <p>Consulting with {{ targetExtension }}...</p>
+      <button @click="completeTransfer">Complete Transfer</button>
+      <button @click="cancelTransfer">Cancel</button>
+    </div>
+  </div>
+</template>
+```
+
+## Key Composables
+
+| Composable        | Purpose                       |
+| ----------------- | ----------------------------- |
+| `useCallTransfer` | Transfer operations and state |
+
+## Related
+
+- [Basic Call](/examples/basic-call)
+- [Multi-Line](/examples/multi-line)

--- a/docs/examples/cdr-dashboard.md
+++ b/docs/examples/cdr-dashboard.md
@@ -1,0 +1,84 @@
+# CDR Dashboard
+
+Call detail records and reporting.
+
+::: tip Try It Live
+Run `pnpm dev` → Navigate to **CDRDashboardDemo** in the playground
+:::
+
+## Overview
+
+CDR dashboard features:
+
+- Call history search
+- Duration and disposition tracking
+- Export capabilities
+- Date range filtering
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useAmiCDR } from 'vuesip'
+
+const { records, searchCDR, exportCSV, totalCalls, avgDuration } = useAmiCDR()
+
+const dateRange = ref({
+  start: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000),
+  end: new Date(),
+})
+</script>
+
+<template>
+  <div class="cdr-dashboard">
+    <!-- Summary -->
+    <div class="summary">
+      <div class="stat">
+        <span class="value">{{ totalCalls }}</span>
+        <span class="label">Total Calls</span>
+      </div>
+      <div class="stat">
+        <span class="value">{{ avgDuration }}s</span>
+        <span class="label">Avg Duration</span>
+      </div>
+    </div>
+
+    <!-- Records Table -->
+    <table class="cdr-table">
+      <thead>
+        <tr>
+          <th>Date</th>
+          <th>From</th>
+          <th>To</th>
+          <th>Duration</th>
+          <th>Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="record in records" :key="record.uniqueid">
+          <td>{{ new Date(record.calldate).toLocaleString() }}</td>
+          <td>{{ record.src }}</td>
+          <td>{{ record.dst }}</td>
+          <td>{{ record.billsec }}s</td>
+          <td>{{ record.disposition }}</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <button @click="exportCSV">Export CSV</button>
+  </div>
+</template>
+```
+
+## Key Composables
+
+| Composable  | Purpose                |
+| ----------- | ---------------------- |
+| `useAmiCDR` | CDR records and search |
+
+## Related
+
+- [Agent Login](/examples/agent-login)
+- [Queue Monitor](/examples/queue-monitor)
+- [AMI Guide](/guide/ami-cdr)

--- a/docs/examples/conference-gallery.md
+++ b/docs/examples/conference-gallery.md
@@ -1,0 +1,91 @@
+# Conference Gallery
+
+Gallery layout for conference video participants.
+
+::: tip Try It Live
+Run `pnpm dev` → Navigate to **ConferenceGalleryDemo** in the playground
+:::
+
+## Overview
+
+Gallery layout features:
+
+- Grid layout for participants
+- Active speaker highlighting
+- Responsive grid sizing
+- Pin/spotlight participants
+- Layout mode switching
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useConference, useGalleryLayout, useActiveSpeaker } from 'vuesip'
+
+const containerRef = ref<HTMLElement>()
+const { participants } = useConference()
+const { activeSpeaker } = useActiveSpeaker(participants)
+
+const {
+  layout,
+  gridCols,
+  gridRows,
+  gridStyle,
+  tileDimensions,
+  setLayout,
+  pinParticipant,
+  unpinParticipant,
+  pinnedParticipantId,
+} = useGalleryLayout(participants, {
+  containerSize: containerRef,
+  gap: 8,
+  maxCols: 4,
+  maxRows: 4,
+  activeSpeakerId: computed(() => activeSpeaker.value?.id),
+})
+</script>
+
+<template>
+  <div ref="containerRef" class="gallery" :style="gridStyle">
+    <div
+      v-for="participant in participants"
+      :key="participant.id"
+      :class="[
+        'tile',
+        { speaking: participant.id === activeSpeaker?.id },
+        { pinned: participant.id === pinnedParticipantId },
+      ]"
+      :style="{
+        width: `${tileDimensions.width}px`,
+        height: `${tileDimensions.height}px`,
+      }"
+      @dblclick="pinParticipant(participant.id)"
+    >
+      <video :srcObject="participant.videoStream" autoplay playsinline />
+      <span class="name">{{ participant.displayName }}</span>
+    </div>
+  </div>
+</template>
+```
+
+## Layout Modes
+
+| Mode        | Description             |
+| ----------- | ----------------------- |
+| `grid`      | Equal-sized tiles       |
+| `speaker`   | Focus on active speaker |
+| `sidebar`   | Main + sidebar tiles    |
+| `spotlight` | Single participant      |
+
+## Key Composables
+
+| Composable         | Purpose           |
+| ------------------ | ----------------- |
+| `useGalleryLayout` | Grid calculations |
+| `useActiveSpeaker` | Speaker detection |
+
+## Related
+
+- [Conference Calls](/examples/conference)
+- [Video Calling](/examples/video-call)

--- a/docs/examples/conference.md
+++ b/docs/examples/conference.md
@@ -1,0 +1,163 @@
+# Conference Calls
+
+Multi-party audio and video conference calling with participant management.
+
+::: tip Try It Live
+Run `pnpm dev` → Navigate to **ConferenceCallDemo** in the playground
+:::
+
+## Overview
+
+The conference call demo showcases:
+
+- Multi-party audio/video conferences
+- Participant list and management
+- Mute individual participants
+- Join/leave notifications
+- Active speaker detection
+- Conference moderation controls
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { useSipClient, useConference, useActiveSpeaker } from 'vuesip'
+
+const { isRegistered } = useSipClient()
+
+const {
+  conferenceState,
+  participants,
+  isInConference,
+  joinConference,
+  leaveConference,
+  muteParticipant,
+  kickParticipant,
+} = useConference()
+
+const { activeSpeaker, activeSpeakers } = useActiveSpeaker(participants)
+
+const conferenceId = ref('')
+
+async function handleJoin() {
+  if (conferenceId.value) {
+    await joinConference(conferenceId.value, {
+      audio: true,
+      video: true,
+    })
+  }
+}
+</script>
+
+<template>
+  <div class="conference-demo">
+    <!-- Join Conference -->
+    <div v-if="!isInConference" class="join-form">
+      <input v-model="conferenceId" placeholder="Conference ID" />
+      <button @click="handleJoin" :disabled="!conferenceId">Join Conference</button>
+    </div>
+
+    <!-- Active Conference -->
+    <div v-else class="conference-active">
+      <div class="conference-header">
+        <h3>Conference: {{ conferenceId }}</h3>
+        <span class="participant-count"> {{ participants.length }} participants </span>
+      </div>
+
+      <!-- Active Speaker Indicator -->
+      <div v-if="activeSpeaker" class="active-speaker">
+        Speaking: {{ activeSpeaker.displayName }}
+      </div>
+
+      <!-- Participant Grid -->
+      <div class="participant-grid">
+        <div
+          v-for="participant in participants"
+          :key="participant.id"
+          :class="['participant-tile', { speaking: activeSpeakers.includes(participant) }]"
+        >
+          <video
+            v-if="participant.videoStream"
+            :srcObject="participant.videoStream"
+            autoplay
+            playsinline
+            :muted="participant.isLocal"
+          />
+          <div class="participant-info">
+            <span class="name">{{ participant.displayName }}</span>
+            <span v-if="participant.isMuted" class="muted-badge">Muted</span>
+          </div>
+
+          <!-- Moderator Controls -->
+          <div class="controls" v-if="!participant.isLocal">
+            <button @click="muteParticipant(participant.id)">
+              {{ participant.isMuted ? 'Unmute' : 'Mute' }}
+            </button>
+            <button @click="kickParticipant(participant.id)">Remove</button>
+          </div>
+        </div>
+      </div>
+
+      <button @click="leaveConference" class="leave-btn">Leave Conference</button>
+    </div>
+  </div>
+</template>
+```
+
+## Features
+
+- **Multi-Party Support**: Up to 50+ participants
+- **Audio/Video**: Full bidirectional media
+- **Active Speaker**: Automatic detection and highlighting
+- **Participant Management**: Mute, kick, promote
+- **Join/Leave Events**: Real-time notifications
+- **Moderation**: Host controls for managing participants
+
+## Key Composables
+
+| Composable               | Purpose                                         |
+| ------------------------ | ----------------------------------------------- |
+| `useConference`          | Conference lifecycle and participant management |
+| `useActiveSpeaker`       | Detect who is currently speaking                |
+| `useGalleryLayout`       | Grid layout calculations for video tiles        |
+| `useParticipantControls` | Individual participant controls                 |
+
+## Conference States
+
+| State     | Description                   |
+| --------- | ----------------------------- |
+| `idle`    | Not in a conference           |
+| `joining` | Connecting to conference      |
+| `active`  | In an active conference       |
+| `leaving` | Disconnecting from conference |
+
+## Advanced Features
+
+### Active Speaker Detection
+
+```typescript
+const { activeSpeaker, speakerHistory } = useActiveSpeaker(participants, {
+  threshold: 0.15, // Audio level threshold
+  debounceMs: 300, // Prevent rapid switching
+  historySize: 10, // Track recent speakers
+})
+```
+
+### Gallery Layout
+
+```typescript
+const { gridCols, gridRows, tileDimensions, gridStyle } = useGalleryLayout(participants, {
+  containerSize: containerRef,
+  gap: 8,
+  maxCols: 4,
+  maxRows: 4,
+  aspectRatio: 16 / 9,
+})
+```
+
+## Related
+
+- [Conference Gallery](/examples/conference-gallery)
+- [Active Speaker Detection](/examples/active-speaker)
+- [Video Calling](/examples/video-call)
+- [API: useConference](/api/composables#useconference)

--- a/docs/examples/connection-recovery.md
+++ b/docs/examples/connection-recovery.md
@@ -1,0 +1,69 @@
+# Connection Recovery
+
+Automatic reconnection and session recovery for network issues.
+
+::: tip Try It Live
+Run `pnpm dev` → Navigate to **ConnectionRecoveryDemo** in the playground
+:::
+
+## Overview
+
+Connection recovery features:
+
+- Connection monitoring
+- Automatic reconnection attempts
+- Exponential backoff
+- Session state preservation
+- ICE restart handling
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { useConnectionRecovery } from 'vuesip'
+
+const { recoveryState, isRecovering, attemptCount, lastError, manualReconnect, cancelRecovery } =
+  useConnectionRecovery({
+    maxAttempts: 5,
+    baseDelayMs: 1000,
+    maxDelayMs: 30000,
+    enableIceRestart: true,
+  })
+</script>
+
+<template>
+  <div class="recovery-demo">
+    <div :class="['status', recoveryState]">
+      {{ recoveryState }}
+    </div>
+
+    <div v-if="isRecovering">
+      <p>Reconnecting... Attempt {{ attemptCount }}</p>
+      <button @click="cancelRecovery">Cancel</button>
+    </div>
+
+    <button v-if="recoveryState === 'failed'" @click="manualReconnect">Retry Connection</button>
+  </div>
+</template>
+```
+
+## Key Composables
+
+| Composable              | Purpose                         |
+| ----------------------- | ------------------------------- |
+| `useConnectionRecovery` | Automatic reconnection handling |
+| `useSessionPersistence` | Session state preservation      |
+
+## Recovery States
+
+| State          | Description          |
+| -------------- | -------------------- |
+| `connected`    | Normal operation     |
+| `disconnected` | Lost connection      |
+| `recovering`   | Attempting reconnect |
+| `failed`       | Recovery failed      |
+
+## Related
+
+- [Call Quality](/examples/call-quality)
+- [Session Persistence](/examples/settings)

--- a/docs/examples/dtmf.md
+++ b/docs/examples/dtmf.md
@@ -1,0 +1,149 @@
+# DTMF Tones
+
+Send DTMF (touch) tones during active calls for IVR navigation and feature codes.
+
+::: tip Try It Live
+Run `pnpm dev` → Navigate to **DtmfDemo** in the playground
+:::
+
+## Overview
+
+DTMF (Dual-Tone Multi-Frequency) tones are used to:
+
+- Navigate IVR (Interactive Voice Response) menus
+- Enter PIN codes and account numbers
+- Dial feature codes (e.g., \*72 for call forwarding)
+- Control conference bridges
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { useCallSession, useDTMF } from 'vuesip'
+
+const { currentCall } = useCallSession()
+const { sendDTMF, sendDTMFSequence, isSending } = useDTMF(currentCall)
+
+const dialpad = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '*', '0', '#']
+const enteredDigits = ref('')
+
+async function handleDigit(digit: string) {
+  enteredDigits.value += digit
+  await sendDTMF(digit)
+}
+
+async function handleSequence() {
+  // Send PIN with delays between digits
+  await sendDTMFSequence('1234#', { intervalMs: 200 })
+}
+
+function clear() {
+  enteredDigits.value = ''
+}
+</script>
+
+<template>
+  <div class="dtmf-demo">
+    <!-- Display -->
+    <div class="display">
+      <input :value="enteredDigits" readonly placeholder="Enter digits" />
+      <button @click="clear">Clear</button>
+    </div>
+
+    <!-- Dialpad -->
+    <div class="dialpad">
+      <button
+        v-for="digit in dialpad"
+        :key="digit"
+        @click="handleDigit(digit)"
+        :disabled="!currentCall || isSending"
+        class="digit-btn"
+      >
+        {{ digit }}
+      </button>
+    </div>
+
+    <!-- Quick Actions -->
+    <div class="actions">
+      <button @click="sendDTMFSequence('*72')">Call Forward On</button>
+      <button @click="sendDTMFSequence('*73')">Call Forward Off</button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.dialpad {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+  max-width: 240px;
+}
+
+.digit-btn {
+  aspect-ratio: 1;
+  font-size: 1.5rem;
+  font-weight: bold;
+}
+</style>
+```
+
+## Features
+
+- **Single Digit**: Send individual DTMF tones
+- **Sequences**: Send multiple digits with configurable delays
+- **Configurable Duration**: Set tone length (default: 100ms)
+- **Visual Feedback**: Show which digits have been sent
+- **Feature Codes**: Quick access to common PBX features
+
+## Key Composables
+
+| Composable       | Purpose                             |
+| ---------------- | ----------------------------------- |
+| `useDTMF`        | Send DTMF tones during active calls |
+| `useCallSession` | Provides active call context        |
+
+## API Reference
+
+```typescript
+import { useDTMF } from 'vuesip'
+
+const {
+  // Send single digit
+  sendDTMF, // (digit: string, duration?: number) => Promise<void>
+
+  // Send sequence with delays
+  sendDTMFSequence, // (sequence: string, options?: DTMFSequenceOptions) => Promise<void>
+
+  // State
+  isSending, // Ref<boolean> - Is currently sending
+  lastSent, // Ref<string | null> - Last digit sent
+} = useDTMF(callSession)
+```
+
+## Sequence Options
+
+```typescript
+await sendDTMFSequence('1234#', {
+  intervalMs: 200, // Delay between digits (default: 100)
+  durationMs: 100, // Tone duration (default: 100)
+  onDigit: (digit) => console.log(`Sent: ${digit}`),
+})
+```
+
+## Common Feature Codes
+
+| Code  | Function             |
+| ----- | -------------------- |
+| `*72` | Call Forward Enable  |
+| `*73` | Call Forward Disable |
+| `*67` | Block Caller ID      |
+| `*69` | Call Return          |
+| `*70` | Disable Call Waiting |
+| `#`   | Confirm/Submit       |
+
+## Related
+
+- [Basic Audio Call](/examples/basic-call)
+- [Call Controls](/examples/hold-mute)
+- [Call Controls Guide](/guide/call-controls)
+- [API: useDTMF](/api/composables#usedtmf)

--- a/docs/examples/hold-mute.md
+++ b/docs/examples/hold-mute.md
@@ -1,0 +1,50 @@
+# Hold & Mute
+
+Basic call controls for holding and muting calls.
+
+::: tip Try It Live
+Run `pnpm dev` → Navigate to **CallControlsDemo** in the playground
+:::
+
+## Overview
+
+Essential call controls:
+
+- Hold/unhold calls
+- Mute/unmute microphone
+- Mute patterns for specific scenarios
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { useCallSession, useCallHold } from 'vuesip'
+
+const { currentCall, toggleMute, isMuted } = useCallSession()
+const { hold, unhold, isHeld } = useCallHold(currentCall)
+</script>
+
+<template>
+  <div class="controls-demo">
+    <button @click="toggleMute">
+      {{ isMuted ? 'Unmute' : 'Mute' }}
+    </button>
+    <button @click="isHeld ? unhold() : hold()">
+      {{ isHeld ? 'Resume' : 'Hold' }}
+    </button>
+  </div>
+</template>
+```
+
+## Key Composables
+
+| Composable       | Purpose                |
+| ---------------- | ---------------------- |
+| `useCallSession` | Mute controls          |
+| `useCallHold`    | Hold/unhold operations |
+
+## Related
+
+- [Basic Call](/examples/basic-call)
+- [DTMF Tones](/examples/dtmf)
+- [Call Controls Guide](/guide/call-controls)

--- a/docs/examples/learning-paths.md
+++ b/docs/examples/learning-paths.md
@@ -1,0 +1,140 @@
+# Learning Paths
+
+Choose a learning path based on your experience level and goals.
+
+## Beginner Path
+
+Perfect for developers new to VoIP/SIP or Vue.js WebRTC applications.
+
+### Step 1: Basic Call Setup
+
+1. [Quick Start](/examples/quick-start) - Get connected in 3 minutes
+2. [Basic Audio Call](/examples/basic-call) - Understand call lifecycle
+3. [Audio Devices](/examples/audio-devices) - Manage microphones and speakers
+
+### Step 2: Call Controls
+
+4. [DTMF Tones](/examples/dtmf) - Send touch tones during calls
+5. [Hold & Mute](/examples/hold-mute) - Basic call controls
+6. [Call Timer](/examples/call-timer) - Track call duration
+
+### Step 3: User Experience
+
+7. [Call History](/examples/call-history) - Track past calls
+8. [Settings Persistence](/examples/settings) - Save user preferences
+
+**Estimated Time**: 2-3 hours
+
+---
+
+## Intermediate Path
+
+For developers ready to add advanced calling features.
+
+### Step 1: Enhanced Calling
+
+1. [Video Calling](/examples/video-call) - Add video to your calls
+2. [Picture-in-Picture](/examples/picture-in-picture) - PiP video support
+3. [Screen Sharing](/examples/screen-sharing) - Share your screen
+
+### Step 2: Call Quality
+
+4. [Quality Monitoring](/examples/call-quality) - Monitor call quality metrics
+5. [Connection Recovery](/examples/connection-recovery) - Handle network issues
+
+### Step 3: Multi-Party
+
+6. [Multi-Line](/examples/multi-line) - Handle multiple concurrent calls
+7. [Conference Calls](/examples/conference) - Multi-party audio/video
+
+### Step 4: Communication
+
+8. [Presence & BLF](/examples/presence) - User status monitoring
+9. [SIP Messaging](/examples/sip-messaging) - Instant messaging
+
+**Estimated Time**: 4-6 hours
+
+---
+
+## Advanced Path
+
+For building production call center and enterprise applications.
+
+### Step 1: Conference Features
+
+1. [Conference Gallery](/examples/conference-gallery) - Gallery layout for participants
+2. [Call Transfer](/examples/call-transfer) - Blind and attended transfers
+
+### Step 2: Call Center Integration
+
+3. [Agent Login](/examples/agent-login) - Call center agent authentication
+4. [Queue Monitor](/examples/queue-monitor) - Live queue statistics
+5. [CDR Dashboard](/examples/cdr-dashboard) - Call detail records
+
+### Step 3: AI Features
+
+6. [Real-Time Transcription](/examples/transcription) - Live speech-to-text
+7. [Keyword Detection](/examples/transcription-keywords) - Detect important phrases
+
+### Step 4: Advanced Recording
+
+8. [Call Recording](/examples/call-recording) - Server-side recording
+9. [Voicemail](/examples/voicemail) - Voicemail management
+
+**Estimated Time**: 6-8 hours
+
+---
+
+## Feature-Specific Paths
+
+### Video Application Developer
+
+Focus on video calling and screen sharing:
+
+1. [Video Calling](/examples/video-call)
+2. [Picture-in-Picture](/examples/picture-in-picture)
+3. [Screen Sharing](/examples/screen-sharing)
+4. [Conference Gallery](/examples/conference-gallery)
+
+### Call Center Developer
+
+Focus on call center features:
+
+1. [Agent Login](/examples/agent-login)
+2. [Queue Monitor](/examples/queue-monitor)
+3. [CDR Dashboard](/examples/cdr-dashboard)
+4. [Call Recording](/examples/call-recording)
+
+### AI/ML Developer
+
+Focus on transcription and AI features:
+
+1. [Real-Time Transcription](/examples/transcription)
+2. [Keyword Detection](/examples/transcription-keywords)
+3. [Quality Monitoring](/examples/call-quality)
+
+---
+
+## Interactive Playground
+
+All examples are available in the interactive playground:
+
+```bash
+# Clone the repository
+git clone https://github.com/ironyh/VueSip.git
+cd VueSip
+
+# Install dependencies
+pnpm install
+
+# Start the playground
+pnpm dev
+```
+
+Visit `http://localhost:5173` to explore all 50+ demos with live code.
+
+## Related
+
+- [Quick Start](/examples/quick-start)
+- [Examples Overview](/examples/)
+- [Getting Started Guide](/guide/getting-started)

--- a/docs/examples/multi-line.md
+++ b/docs/examples/multi-line.md
@@ -1,0 +1,66 @@
+# Multi-Line
+
+Handle multiple concurrent calls with line management.
+
+::: tip Try It Live
+Run `pnpm dev` → Navigate to **MultiLineDemo** in the playground
+:::
+
+## Overview
+
+Multi-line phone system supporting:
+
+- Up to 5 concurrent calls
+- Visual call line management
+- Call switching between lines
+- Individual line controls (hold, mute)
+- Call duration tracking per line
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { useMultiLine } from 'vuesip'
+
+const {
+  lines,
+  activeLine,
+  availableLines,
+  makeCallOnLine,
+  switchToLine,
+  holdLine,
+  unholdLine,
+  hangupLine,
+} = useMultiLine({ maxLines: 5 })
+</script>
+
+<template>
+  <div class="multiline-demo">
+    <div class="line-panel">
+      <div
+        v-for="line in lines"
+        :key="line.id"
+        :class="['line', { active: line.id === activeLine?.id }]"
+        @click="switchToLine(line.id)"
+      >
+        <span class="line-number">Line {{ line.number }}</span>
+        <span class="line-status">{{ line.state }}</span>
+        <button @click.stop="holdLine(line.id)">Hold</button>
+        <button @click.stop="hangupLine(line.id)">End</button>
+      </div>
+    </div>
+  </div>
+</template>
+```
+
+## Key Composables
+
+| Composable     | Purpose                    |
+| -------------- | -------------------------- |
+| `useMultiLine` | Multi-line call management |
+
+## Related
+
+- [Basic Call](/examples/basic-call)
+- [Call Transfer](/examples/call-transfer)
+- [Multi-Line Guide](/guide/multi-line)

--- a/docs/examples/picture-in-picture.md
+++ b/docs/examples/picture-in-picture.md
@@ -1,0 +1,149 @@
+# Picture-in-Picture
+
+Browser Picture-in-Picture (PiP) integration for video calls.
+
+::: tip Try It Live
+Run `pnpm dev` → Navigate to **PictureInPictureDemo** in the playground
+:::
+
+## Overview
+
+Picture-in-Picture allows users to:
+
+- Keep video visible while using other tabs/apps
+- Automatic PiP when switching tabs
+- Custom controls in PiP window
+- Seamless video element management
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { useCallSession, usePictureInPicture } from 'vuesip'
+
+const { currentCall } = useCallSession()
+const remoteVideo = ref<HTMLVideoElement>()
+
+const { isSupported, isActive, enterPiP, exitPiP, togglePiP } = usePictureInPicture(remoteVideo, {
+  autoEnterOnTabSwitch: true,
+  width: 400,
+  height: 225,
+})
+
+// Attach remote stream to video element
+watch(
+  () => currentCall.value?.remoteStream,
+  (stream) => {
+    if (remoteVideo.value && stream) {
+      remoteVideo.value.srcObject = stream
+    }
+  }
+)
+</script>
+
+<template>
+  <div class="pip-demo">
+    <div v-if="!isSupported" class="warning">
+      Picture-in-Picture is not supported in this browser.
+    </div>
+
+    <!-- Video Container -->
+    <div class="video-container">
+      <video ref="remoteVideo" autoplay playsinline />
+
+      <!-- PiP Controls -->
+      <div class="pip-controls">
+        <button @click="togglePiP" :disabled="!isSupported || !currentCall">
+          {{ isActive ? 'Exit PiP' : 'Enter PiP' }}
+        </button>
+      </div>
+    </div>
+
+    <p class="hint">
+      {{
+        isActive
+          ? 'Video is in Picture-in-Picture mode'
+          : 'Click button or switch tabs to activate PiP'
+      }}
+    </p>
+  </div>
+</template>
+```
+
+## Features
+
+- **Browser PiP API**: Uses native Picture-in-Picture
+- **Auto-Enter**: Automatically enters PiP when tab loses focus
+- **Custom Size**: Configure PiP window dimensions
+- **Toggle Control**: Easy on/off switching
+- **Event Handling**: Callbacks for enter/exit events
+
+## Key Composables
+
+| Composable            | Purpose                            |
+| --------------------- | ---------------------------------- |
+| `usePictureInPicture` | PiP lifecycle management           |
+| `useVideoInset`       | Alternative: CSS-based video inset |
+
+## Configuration Options
+
+```typescript
+const pip = usePictureInPicture(videoRef, {
+  // Auto-enter PiP when tab loses focus
+  autoEnterOnTabSwitch: true,
+
+  // PiP window dimensions
+  width: 400,
+  height: 225,
+
+  // Event callbacks
+  onEnter: () => console.log('Entered PiP'),
+  onExit: () => console.log('Exited PiP'),
+  onResize: (width, height) => console.log(`Resized: ${width}x${height}`),
+})
+```
+
+## Return Values
+
+```typescript
+const {
+  isSupported, // Ref<boolean> - Is PiP supported
+  isActive, // Ref<boolean> - Is PiP currently active
+  pipWindow, // Ref<PictureInPictureWindow | null>
+
+  enterPiP, // () => Promise<void>
+  exitPiP, // () => Promise<void>
+  togglePiP, // () => Promise<void>
+} = usePictureInPicture(videoRef, options)
+```
+
+## Browser Support
+
+| Browser | Support                  |
+| ------- | ------------------------ |
+| Chrome  | ✅ Full support          |
+| Edge    | ✅ Full support          |
+| Firefox | ⚠️ Limited (no auto-PiP) |
+| Safari  | ✅ Full support          |
+
+## CSS Video Inset Alternative
+
+For more control, use `useVideoInset` for a CSS-based solution:
+
+```typescript
+import { useVideoInset } from 'vuesip'
+
+const { position, size, isDragging, setPosition, setSize } = useVideoInset({
+  position: 'bottom-right',
+  size: 'medium',
+  draggable: true,
+})
+```
+
+## Related
+
+- [Video Calling](/examples/video-call)
+- [Conference Gallery](/examples/conference-gallery)
+- [Video Guide](/guide/video-calling)
+- [API: usePictureInPicture](/api/composables#usepictureinpicture)

--- a/docs/examples/presence.md
+++ b/docs/examples/presence.md
@@ -1,0 +1,179 @@
+# Presence & BLF
+
+User presence status and Busy Lamp Field (BLF) monitoring for extension status.
+
+::: tip Try It Live
+Run `pnpm dev` → Navigate to **PresenceDemo** or **BLFDemo** in the playground
+:::
+
+## Overview
+
+Presence features enable:
+
+- Online/offline/away status tracking
+- Custom status messages
+- BLF (Busy Lamp Field) extension monitoring
+- Quick dial from presence indicators
+- Real-time status subscriptions
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { useSipClient, usePresence, useFreePBXPresence } from 'vuesip'
+
+const { isRegistered } = useSipClient()
+
+// User presence
+const { status, statusMessage, setStatus, setStatusMessage, subscribeToUser, watchedUsers } =
+  usePresence()
+
+// BLF monitoring
+const { blfStatus, subscribeToBLF, unsubscribeFromBLF } = useFreePBXPresence()
+
+// Extensions to monitor
+const monitoredExtensions = ref(['1001', '1002', '1003', '1004'])
+
+onMounted(() => {
+  // Subscribe to BLF for each extension
+  monitoredExtensions.value.forEach((ext) => {
+    subscribeToBLF(ext)
+  })
+})
+</script>
+
+<template>
+  <div class="presence-demo">
+    <!-- My Status -->
+    <div class="my-status">
+      <h3>My Status</h3>
+      <select :value="status" @change="setStatus($event.target.value)">
+        <option value="available">Available</option>
+        <option value="busy">Busy</option>
+        <option value="away">Away</option>
+        <option value="dnd">Do Not Disturb</option>
+        <option value="offline">Offline</option>
+      </select>
+      <input
+        :value="statusMessage"
+        @input="setStatusMessage($event.target.value)"
+        placeholder="Status message..."
+      />
+    </div>
+
+    <!-- BLF Panel -->
+    <div class="blf-panel">
+      <h3>Extension Status</h3>
+      <div class="blf-grid">
+        <div
+          v-for="ext in monitoredExtensions"
+          :key="ext"
+          class="blf-item"
+          :class="blfStatus[ext]?.state || 'unknown'"
+        >
+          <span class="indicator"></span>
+          <span class="extension">{{ ext }}</span>
+          <span class="name">{{ blfStatus[ext]?.displayName || 'Unknown' }}</span>
+          <button @click="makeCall(ext)" :disabled="blfStatus[ext]?.state === 'busy'">Call</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.blf-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px;
+  border-radius: 4px;
+}
+
+.blf-item .indicator {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+}
+
+.blf-item.available .indicator {
+  background: #22c55e;
+}
+.blf-item.busy .indicator {
+  background: #ef4444;
+}
+.blf-item.ringing .indicator {
+  background: #f59e0b;
+  animation: pulse 1s infinite;
+}
+.blf-item.away .indicator {
+  background: #eab308;
+}
+.blf-item.offline .indicator {
+  background: #6b7280;
+}
+</style>
+```
+
+## Features
+
+- **Presence Status**: Track user availability in real-time
+- **Custom Messages**: Set status messages (e.g., "In a meeting")
+- **BLF Monitoring**: Watch extension busy/idle state
+- **Quick Dial**: One-click calling from BLF panel
+- **Subscriptions**: Subscribe to specific users or extensions
+- **Visual Indicators**: Color-coded status display
+
+## Key Composables
+
+| Composable           | Purpose                          |
+| -------------------- | -------------------------------- |
+| `usePresence`        | User presence status management  |
+| `useFreePBXPresence` | FreePBX-specific BLF integration |
+
+## Presence States
+
+| State       | Color  | Description            |
+| ----------- | ------ | ---------------------- |
+| `available` | Green  | User is available      |
+| `busy`      | Red    | User is on a call      |
+| `ringing`   | Amber  | User has incoming call |
+| `away`      | Yellow | User is away           |
+| `dnd`       | Red    | Do Not Disturb         |
+| `offline`   | Gray   | User is offline        |
+
+## BLF Status
+
+```typescript
+interface BLFStatus {
+  extension: string
+  state: 'available' | 'busy' | 'ringing' | 'offline'
+  displayName?: string
+  callerId?: string // When on a call
+  direction?: 'inbound' | 'outbound'
+}
+```
+
+## Subscribe to Users
+
+```typescript
+const { subscribeToUser, watchedUsers } = usePresence()
+
+// Subscribe to specific users
+await subscribeToUser('sip:alice@example.com')
+await subscribeToUser('sip:bob@example.com')
+
+// Watch their status
+watchEffect(() => {
+  for (const [uri, status] of watchedUsers.value) {
+    console.log(`${uri}: ${status.state}`)
+  }
+})
+```
+
+## Related
+
+- [SIP Messaging](/examples/sip-messaging)
+- [Basic Call](/examples/basic-call)
+- [Presence Guide](/guide/presence-messaging)
+- [API: usePresence](/api/composables#usepresence)

--- a/docs/examples/queue-monitor.md
+++ b/docs/examples/queue-monitor.md
@@ -1,0 +1,63 @@
+# Queue Monitor
+
+Live queue statistics and monitoring.
+
+::: tip Try It Live
+Run `pnpm dev` → Navigate to **QueueMonitorDemo** in the playground
+:::
+
+## Overview
+
+Queue monitoring features:
+
+- Queue wait times
+- Calls waiting count
+- Service level metrics
+- Agent availability
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { useAmiQueues } from 'vuesip'
+
+const { queues, refreshQueues } = useAmiQueues()
+</script>
+
+<template>
+  <div class="queue-monitor-demo">
+    <div v-for="queue in queues" :key="queue.name" class="queue-card">
+      <h4>{{ queue.name }}</h4>
+      <div class="metrics">
+        <div class="metric">
+          <span class="value">{{ queue.callsWaiting }}</span>
+          <span class="label">Waiting</span>
+        </div>
+        <div class="metric">
+          <span class="value">{{ queue.avgWaitTime }}s</span>
+          <span class="label">Avg Wait</span>
+        </div>
+        <div class="metric">
+          <span class="value">{{ queue.agentsAvailable }}</span>
+          <span class="label">Agents Ready</span>
+        </div>
+        <div class="metric">
+          <span class="value">{{ queue.serviceLevel }}%</span>
+          <span class="label">SL</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+```
+
+## Key Composables
+
+| Composable     | Purpose          |
+| -------------- | ---------------- |
+| `useAmiQueues` | Queue statistics |
+
+## Related
+
+- [Agent Login](/examples/agent-login)
+- [CDR Dashboard](/examples/cdr-dashboard)

--- a/docs/examples/quick-start.md
+++ b/docs/examples/quick-start.md
@@ -1,0 +1,106 @@
+# Quick Start
+
+Get up and running with VueSip in under 3 minutes.
+
+::: tip Try It Live
+Run `pnpm dev` → Navigate to **BasicCallDemo** in the playground
+:::
+
+## Installation
+
+```bash
+# Using pnpm (recommended)
+pnpm add vuesip
+
+# Using npm
+npm install vuesip
+
+# Using yarn
+yarn add vuesip
+```
+
+## Basic Setup
+
+### 1. Create a SIP Connection
+
+```vue
+<script setup lang="ts">
+import { useSipClient } from 'vuesip'
+
+const { connect, disconnect, isConnected, isRegistered, error } = useSipClient()
+
+// Connect to your SIP server
+async function handleConnect() {
+  await connect({
+    uri: 'sip:1000@your-pbx.com',
+    password: 'your-password',
+    server: 'wss://your-pbx.com:8089/ws',
+  })
+}
+</script>
+
+<template>
+  <div>
+    <p>Status: {{ isConnected ? 'Connected' : 'Disconnected' }}</p>
+    <p>Registered: {{ isRegistered ? 'Yes' : 'No' }}</p>
+    <button @click="handleConnect">Connect</button>
+    <button @click="disconnect">Disconnect</button>
+  </div>
+</template>
+```
+
+### 2. Make Your First Call
+
+```vue
+<script setup lang="ts">
+import { useSipClient, useCallSession } from 'vuesip'
+
+const { isRegistered } = useSipClient()
+const { currentCall, makeCall, hangup, answer } = useCallSession()
+
+const targetNumber = ref('')
+
+async function dial() {
+  if (targetNumber.value) {
+    await makeCall(targetNumber.value)
+  }
+}
+</script>
+
+<template>
+  <div v-if="isRegistered">
+    <input v-model="targetNumber" placeholder="Enter number" />
+    <button @click="dial" :disabled="!targetNumber">Call</button>
+
+    <div v-if="currentCall">
+      <p>Call Status: {{ currentCall.state }}</p>
+      <button @click="hangup">Hang Up</button>
+    </div>
+  </div>
+</template>
+```
+
+## What's Next?
+
+Now that you have a basic call working, explore these features:
+
+| Feature       | Guide                                       | Example                                       |
+| ------------- | ------------------------------------------- | --------------------------------------------- |
+| Video Calling | [Video Guide](/guide/video-calling)         | [Video Demo](/examples/video-call)            |
+| Call Quality  | [Quality Guide](/guide/call-quality)        | [Quality Demo](/examples/call-quality)        |
+| Transcription | [Transcription Guide](/guide/transcription) | [Transcription Demo](/examples/transcription) |
+| Multi-Line    | [Multi-Line Guide](/guide/multi-line)       | [Multi-Line Demo](/examples/multi-line)       |
+
+## Key Composables
+
+| Composable        | Purpose                                    |
+| ----------------- | ------------------------------------------ |
+| `useSipClient`    | SIP connection and registration management |
+| `useCallSession`  | Call state, making/answering calls         |
+| `useMediaDevices` | Audio/video device selection               |
+
+## Related
+
+- [Getting Started Guide](/guide/getting-started)
+- [API: useSipClient](/api/composables#usesipclient)
+- [Learning Paths](/examples/learning-paths)

--- a/docs/examples/screen-sharing.md
+++ b/docs/examples/screen-sharing.md
@@ -1,0 +1,60 @@
+# Screen Sharing
+
+Share your screen during calls.
+
+::: tip Try It Live
+Run `pnpm dev` → Navigate to **ScreenSharingDemo** in the playground
+:::
+
+## Overview
+
+Screen sharing features:
+
+- Screen/window/tab selection
+- Start/stop sharing
+- Replace video track with screen
+- Sharing indicator
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useCallSession, useMediaDevices } from 'vuesip'
+
+const { currentCall } = useCallSession()
+const { startScreenShare, stopScreenShare, isScreenSharing } = useMediaDevices()
+
+async function toggleScreenShare() {
+  if (isScreenSharing.value) {
+    await stopScreenShare()
+  } else {
+    await startScreenShare({
+      video: { cursor: 'always' },
+      audio: true, // Share system audio
+    })
+  }
+}
+</script>
+
+<template>
+  <div class="screen-share-demo">
+    <button @click="toggleScreenShare" :class="{ active: isScreenSharing }">
+      {{ isScreenSharing ? 'Stop Sharing' : 'Share Screen' }}
+    </button>
+
+    <div v-if="isScreenSharing" class="sharing-indicator">Screen sharing active</div>
+  </div>
+</template>
+```
+
+## Key Composables
+
+| Composable        | Purpose                    |
+| ----------------- | -------------------------- |
+| `useMediaDevices` | Screen capture and sharing |
+
+## Related
+
+- [Video Calling](/examples/video-call)
+- [Picture-in-Picture](/examples/picture-in-picture)

--- a/docs/examples/settings.md
+++ b/docs/examples/settings.md
@@ -1,0 +1,94 @@
+# Settings Persistence
+
+Application settings with persistent storage.
+
+::: tip Try It Live
+Run `pnpm dev` → Navigate to **SettingsDemo** in the playground
+:::
+
+## Overview
+
+Settings management features:
+
+- Audio preferences
+- Ringtone selection
+- Notification settings
+- Theme preferences
+- Session persistence
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { useSessionPersistence } from 'vuesip'
+
+const { savedSessions, saveSession, restoreSession, deleteSession, clearAllSessions } =
+  useSessionPersistence()
+
+// Settings are automatically persisted
+const settings = reactive({
+  ringtone: 'default',
+  volume: 0.8,
+  autoAnswer: false,
+  notifications: true,
+})
+
+// Watch and persist settings changes
+watch(
+  settings,
+  (newSettings) => {
+    localStorage.setItem('vuesip-settings', JSON.stringify(newSettings))
+  },
+  { deep: true }
+)
+</script>
+
+<template>
+  <div class="settings-demo">
+    <h3>Audio Settings</h3>
+    <label>
+      Volume
+      <input type="range" v-model.number="settings.volume" min="0" max="1" step="0.1" />
+    </label>
+
+    <label>
+      Ringtone
+      <select v-model="settings.ringtone">
+        <option value="default">Default</option>
+        <option value="classic">Classic</option>
+        <option value="modern">Modern</option>
+      </select>
+    </label>
+
+    <h3>Behavior</h3>
+    <label>
+      <input type="checkbox" v-model="settings.autoAnswer" />
+      Auto-Answer Calls
+    </label>
+
+    <label>
+      <input type="checkbox" v-model="settings.notifications" />
+      Enable Notifications
+    </label>
+
+    <h3>Saved Sessions</h3>
+    <div v-for="session in savedSessions" :key="session.id">
+      {{ session.name }}
+      <button @click="restoreSession(session.id)">Restore</button>
+      <button @click="deleteSession(session.id)">Delete</button>
+    </div>
+  </div>
+</template>
+```
+
+## Key Composables
+
+| Composable              | Purpose               |
+| ----------------------- | --------------------- |
+| `useSessionPersistence` | Session state storage |
+
+## Related
+
+- [Audio Devices](/examples/audio-devices)
+- [Call History](/examples/call-history)
+- [Connection Recovery](/examples/connection-recovery)

--- a/docs/examples/sip-messaging.md
+++ b/docs/examples/sip-messaging.md
@@ -1,0 +1,67 @@
+# SIP Messaging
+
+Instant messaging over SIP MESSAGE.
+
+::: tip Try It Live
+Run `pnpm dev` → Navigate to **SipMessagingDemo** in the playground
+:::
+
+## Overview
+
+SIP messaging features:
+
+- Send/receive SIP messages
+- Message history
+- Delivery confirmation
+- Typing indicators
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useMessaging } from 'vuesip'
+
+const { conversations, sendMessage, markAsRead, onMessage } = useMessaging()
+
+const recipient = ref('')
+const messageText = ref('')
+
+async function handleSend() {
+  if (recipient.value && messageText.value) {
+    await sendMessage(recipient.value, messageText.value)
+    messageText.value = ''
+  }
+}
+</script>
+
+<template>
+  <div class="messaging-demo">
+    <div class="conversations">
+      <div v-for="conv in conversations" :key="conv.id" class="conversation">
+        <h4>{{ conv.displayName }}</h4>
+        <div v-for="msg in conv.messages" :key="msg.id" :class="msg.direction">
+          {{ msg.content }}
+        </div>
+      </div>
+    </div>
+
+    <div class="compose">
+      <input v-model="recipient" placeholder="To: sip:user@example.com" />
+      <input v-model="messageText" placeholder="Message..." @keyup.enter="handleSend" />
+      <button @click="handleSend">Send</button>
+    </div>
+  </div>
+</template>
+```
+
+## Key Composables
+
+| Composable     | Purpose             |
+| -------------- | ------------------- |
+| `useMessaging` | SIP MESSAGE support |
+
+## Related
+
+- [Presence & BLF](/examples/presence)
+- [Presence Guide](/guide/presence-messaging)

--- a/docs/examples/transcription-keywords.md
+++ b/docs/examples/transcription-keywords.md
@@ -1,0 +1,61 @@
+# Keyword Detection
+
+Detect specific words and phrases during transcription.
+
+::: tip Try It Live
+Run `pnpm dev` → Navigate to **TranscriptionDemo** in the playground
+:::
+
+## Overview
+
+Keyword detection features:
+
+- Define keywords/phrases to watch for
+- Real-time alerts when detected
+- Confidence thresholds
+- Custom actions on detection
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { useCallSession, useTranscription } from 'vuesip'
+
+const { currentCall } = useCallSession()
+
+const { transcript, startTranscription, keywordMatches } = useTranscription(currentCall, {
+  keywords: [
+    { phrase: 'escalate', action: 'alert' },
+    { phrase: 'supervisor', action: 'alert' },
+    { phrase: 'cancel', action: 'log' },
+    { phrase: 'refund', action: 'highlight' },
+  ],
+  onKeyword: (keyword, entry) => {
+    console.log(`Keyword "${keyword}" detected:`, entry.text)
+  },
+})
+</script>
+
+<template>
+  <div class="keyword-demo">
+    <div class="keywords-matched">
+      <h4>Detected Keywords</h4>
+      <div v-for="match in keywordMatches" :key="match.id" class="match">
+        <span class="keyword">{{ match.keyword }}</span>
+        <span class="context">{{ match.context }}</span>
+      </div>
+    </div>
+  </div>
+</template>
+```
+
+## Key Composables
+
+| Composable         | Purpose                              |
+| ------------------ | ------------------------------------ |
+| `useTranscription` | Transcription with keyword detection |
+
+## Related
+
+- [Real-Time Transcription](/examples/transcription)
+- [Transcription Guide](/guide/transcription)

--- a/docs/examples/transcription.md
+++ b/docs/examples/transcription.md
@@ -1,0 +1,191 @@
+# Real-Time Transcription
+
+Live speech-to-text transcription during calls with timestamps and speaker identification.
+
+::: tip Try It Live
+Run `pnpm dev` → Navigate to **TranscriptionDemo** in the playground
+:::
+
+## Overview
+
+VueSip provides comprehensive real-time transcription capabilities:
+
+- Live speech-to-text during active calls
+- Millisecond-accurate timestamps
+- Speaker identification (local vs remote)
+- Multiple provider support (Browser, Deepgram, AssemblyAI, Google, Azure)
+- Keyword detection and PII redaction
+- Export to multiple formats
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { useCallSession, useTranscription } from 'vuesip'
+
+const { currentCall } = useCallSession()
+
+const { isTranscribing, transcript, startTranscription, stopTranscription, exportTranscript } =
+  useTranscription(currentCall, {
+    provider: 'browser', // Uses Web Speech API
+    language: 'en-US',
+    includeTimestamps: true,
+    includeSpeakerLabels: true,
+  })
+</script>
+
+<template>
+  <div class="transcription-demo">
+    <!-- Controls -->
+    <div class="controls">
+      <button
+        @click="isTranscribing ? stopTranscription() : startTranscription()"
+        :class="{ active: isTranscribing }"
+      >
+        {{ isTranscribing ? 'Stop' : 'Start' }} Transcription
+      </button>
+
+      <button @click="exportTranscript('txt')">Export TXT</button>
+    </div>
+
+    <!-- Live Transcript -->
+    <div class="transcript">
+      <div v-for="entry in transcript" :key="entry.id" :class="['entry', entry.speaker]">
+        <span class="timestamp">{{ formatTimestamp(entry.timestamp) }}</span>
+        <span class="speaker">{{ entry.speaker === 'local' ? 'You' : 'Remote' }}:</span>
+        <span class="text">{{ entry.text }}</span>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+function formatTimestamp(ms: number): string {
+  const seconds = Math.floor(ms / 1000)
+  const minutes = Math.floor(seconds / 60)
+  const secs = seconds % 60
+  return `${minutes}:${secs.toString().padStart(2, '0')}`
+}
+</script>
+```
+
+## Features
+
+### Core Transcription
+
+- **Real-Time Processing**: Live speech-to-text as conversation happens
+- **Timestamps**: Millisecond-accurate timing for each utterance
+- **Speaker Labels**: Automatic identification of local vs remote speakers
+- **Confidence Scores**: Quality indicators for transcription accuracy
+
+### Provider Support
+
+| Provider     | Type  | Features                               |
+| ------------ | ----- | -------------------------------------- |
+| `browser`    | Free  | Web Speech API, no API key needed      |
+| `deepgram`   | Cloud | High accuracy, real-time streaming     |
+| `assemblyai` | Cloud | Speaker diarization, custom vocabulary |
+| `google`     | Cloud | 125+ languages, enhanced models        |
+| `azure`      | Cloud | Enterprise features, custom models     |
+
+### Advanced Features
+
+- **Keyword Detection**: Alert when specific words/phrases are spoken
+- **PII Redaction**: Automatically mask sensitive information
+- **Custom Vocabulary**: Add domain-specific terms
+- **Multi-Language**: Support for 100+ languages
+
+## Configuration Options
+
+```typescript
+const transcription = useTranscription(callSession, {
+  // Provider selection
+  provider: 'deepgram',
+  apiKey: 'your-api-key',
+
+  // Language settings
+  language: 'en-US',
+
+  // Feature flags
+  includeTimestamps: true,
+  includeSpeakerLabels: true,
+  includeConfidenceScores: true,
+
+  // Advanced options
+  keywords: ['urgent', 'escalate', 'supervisor'],
+  redactPII: true,
+  customVocabulary: ['VueSip', 'WebRTC'],
+
+  // Callbacks
+  onTranscript: (entry) => console.log('New:', entry),
+  onKeyword: (keyword, entry) => alert(`Keyword detected: ${keyword}`),
+})
+```
+
+## Export Formats
+
+```typescript
+// Export to different formats
+await exportTranscript('txt') // Plain text
+await exportTranscript('json') // Structured JSON
+await exportTranscript('srt') // Subtitle format
+await exportTranscript('vtt') // WebVTT format
+```
+
+### Export Example Output (TXT)
+
+```
+Call Transcript - 2024-01-15 14:30:00
+
+[00:00:05] You: Hello, thank you for calling support.
+[00:00:12] Remote: Hi, I'm having an issue with my account.
+[00:00:20] You: I'd be happy to help. Can you describe the problem?
+```
+
+## Key Composables
+
+| Composable         | Purpose                                |
+| ------------------ | -------------------------------------- |
+| `useTranscription` | Core transcription functionality       |
+| `useCallSession`   | Provides call context for audio stream |
+
+## Return Values
+
+```typescript
+const {
+  // State
+  isTranscribing, // Ref<boolean> - Is transcription active
+  isPaused, // Ref<boolean> - Is transcription paused
+  transcript, // Ref<TranscriptEntry[]> - All entries
+  currentText, // Ref<string> - Current partial text
+
+  // Metrics
+  wordCount, // ComputedRef<number> - Total words
+  duration, // ComputedRef<number> - Total duration
+
+  // Actions
+  startTranscription,
+  stopTranscription,
+  pauseTranscription,
+  resumeTranscription,
+  clearTranscript,
+  exportTranscript,
+
+  // Provider info
+  providerCapabilities,
+} = useTranscription(callSession, options)
+```
+
+## Best Practices
+
+1. **Start Early**: Begin transcription when call connects, not after
+2. **Handle Pauses**: Use pause/resume for holds to avoid gaps
+3. **Export Regularly**: Auto-save transcripts for long calls
+4. **Provider Selection**: Use browser API for testing, cloud for production
+
+## Related
+
+- [Keyword Detection](/examples/transcription-keywords)
+- [Transcription Guide](/guide/transcription)
+- [API: useTranscription](/api/composables#usetranscription)
+- [Call Quality](/examples/call-quality)

--- a/docs/examples/video-call.md
+++ b/docs/examples/video-call.md
@@ -1,0 +1,151 @@
+# Video Calling
+
+Bidirectional video calling with camera selection, preview, and advanced controls.
+
+::: tip Try It Live
+Run `pnpm dev` → Navigate to **VideoCallDemo** in the playground
+:::
+
+## Overview
+
+The video call demo showcases:
+
+- Bidirectional video and audio calls
+- Local video preview before connecting
+- Camera enumeration and selection
+- Switch cameras during active calls
+- Enable/disable video mid-call
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useSipClient, useCallSession, useMediaDevices } from 'vuesip'
+
+const { isRegistered } = useSipClient()
+const { currentCall, makeCall, hangup, answer } = useCallSession()
+const { videoInputDevices, selectedVideoInput, selectVideoInput, requestPermissions, localStream } =
+  useMediaDevices()
+
+// Video elements
+const localVideo = ref<HTMLVideoElement>()
+const remoteVideo = ref<HTMLVideoElement>()
+
+// Request camera access on mount
+onMounted(async () => {
+  await requestPermissions(true, true) // audio, video
+})
+
+// Attach streams to video elements
+watch(localStream, (stream) => {
+  if (localVideo.value && stream) {
+    localVideo.value.srcObject = stream
+  }
+})
+
+watch(
+  () => currentCall.value?.remoteStream,
+  (stream) => {
+    if (remoteVideo.value && stream) {
+      remoteVideo.value.srcObject = stream
+    }
+  }
+)
+
+// Make video call
+async function startVideoCall(target: string) {
+  await makeCall(target, {
+    video: true,
+    audio: true,
+  })
+}
+</script>
+
+<template>
+  <div class="video-call-demo">
+    <!-- Camera Selection -->
+    <div class="camera-select">
+      <label>Camera:</label>
+      <select :value="selectedVideoInput?.deviceId" @change="selectVideoInput($event.target.value)">
+        <option v-for="device in videoInputDevices" :key="device.deviceId" :value="device.deviceId">
+          {{ device.label }}
+        </option>
+      </select>
+    </div>
+
+    <!-- Video Preview -->
+    <div class="video-container">
+      <video ref="remoteVideo" class="remote-video" autoplay playsinline />
+      <video ref="localVideo" class="local-video" autoplay playsinline muted />
+    </div>
+
+    <!-- Call Controls -->
+    <div class="controls">
+      <button @click="startVideoCall('1001')">Start Video Call</button>
+      <button v-if="currentCall" @click="hangup">End Call</button>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.video-container {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16/9;
+  background: #000;
+}
+
+.remote-video {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.local-video {
+  position: absolute;
+  bottom: 16px;
+  right: 16px;
+  width: 25%;
+  aspect-ratio: 16/9;
+  border: 2px solid white;
+  border-radius: 8px;
+}
+</style>
+```
+
+## Features
+
+- **Bidirectional Video**: Both parties can send and receive video
+- **Camera Preview**: See yourself before the call starts
+- **Device Selection**: Choose from available cameras
+- **Hot Swap**: Switch cameras without ending the call
+- **Video Toggle**: Turn video on/off during calls
+- **Responsive Layout**: Adaptive video sizing
+
+## Key Composables
+
+| Composable        | Purpose                          |
+| ----------------- | -------------------------------- |
+| `useSipClient`    | SIP connection management        |
+| `useCallSession`  | Call state and video streams     |
+| `useMediaDevices` | Camera enumeration and selection |
+
+## Video Controls During Call
+
+```typescript
+const { toggleVideo, isVideoEnabled, replaceVideoTrack } = useCallSession()
+
+// Toggle video on/off
+await toggleVideo()
+
+// Switch camera mid-call
+await replaceVideoTrack(newCameraDeviceId)
+```
+
+## Related
+
+- [Basic Audio Call](/examples/basic-call)
+- [Picture-in-Picture](/examples/picture-in-picture)
+- [Screen Sharing](/examples/screen-sharing)
+- [Video Calling Guide](/guide/video-calling)

--- a/docs/examples/voicemail.md
+++ b/docs/examples/voicemail.md
@@ -1,0 +1,53 @@
+# Voicemail
+
+Voicemail box management.
+
+::: tip Try It Live
+Run `pnpm dev` → Navigate to **VoicemailDemo** in the playground
+:::
+
+## Overview
+
+Voicemail features:
+
+- Message list
+- Playback controls
+- Delete/archive messages
+- New message notifications
+
+## Quick Start
+
+```vue
+<script setup lang="ts">
+import { useAmiVoicemail } from 'vuesip'
+
+const { messages, unreadCount, playMessage, deleteMessage, markAsRead, refresh } = useAmiVoicemail()
+</script>
+
+<template>
+  <div class="voicemail-demo">
+    <h3>Voicemail ({{ unreadCount }} new)</h3>
+
+    <div class="message-list">
+      <div v-for="msg in messages" :key="msg.id" :class="['message', { unread: !msg.read }]">
+        <span class="from">{{ msg.callerName || msg.callerNumber }}</span>
+        <span class="date">{{ new Date(msg.timestamp).toLocaleString() }}</span>
+        <span class="duration">{{ msg.duration }}s</span>
+        <button @click="playMessage(msg.id)">Play</button>
+        <button @click="deleteMessage(msg.id)">Delete</button>
+      </div>
+    </div>
+  </div>
+</template>
+```
+
+## Key Composables
+
+| Composable        | Purpose              |
+| ----------------- | -------------------- |
+| `useAmiVoicemail` | Voicemail management |
+
+## Related
+
+- [Basic Call](/examples/basic-call)
+- [Voicemail Guide](/guide/voicemail)


### PR DESCRIPTION
## Summary

Previously, the Examples sidebar only showed "Overview" despite having extensive demo documentation in `docs/examples/index.md`. This update adds comprehensive sidebar navigation with 28 new example pages.

### Changes

- **Sidebar Configuration** (`docs/.vitepress/config.ts`): Added 10 categorized sections
- **28 New Example Pages**: Each with consistent structure (overview, quick start code, features, composables table, related links)

### Categories Added

| Category | Pages |
|----------|-------|
| Getting Started | quick-start, learning-paths |
| Core Calling | basic-call, video-call, conference, call-transfer, multi-line |
| Call Controls | dtmf, hold-mute, call-timer, auto-answer |
| Call Quality | call-quality, connection-recovery |
| Transcription | transcription, transcription-keywords |
| Video & Recording | picture-in-picture, screen-sharing, call-recording, conference-gallery |
| Communication | presence, sip-messaging, voicemail |
| Call Center (AMI) | agent-login, queue-monitor, cdr-dashboard |
| Settings & Utilities | audio-devices, call-history, settings |

## Test plan

- [x] VitePress build passes (`pnpm docs:build` - 52.41s)
- [ ] Verify all sidebar links work (no 404s)
- [ ] Check example code accuracy against actual composables

🤖 Generated with [Claude Code](https://claude.com/claude-code)