### PR TITLE
Fix 46elks voice_start hint text

### DIFF
--- a/templates/pwa-softphone/src/components/Elks46Login.vue
+++ b/templates/pwa-softphone/src/components/Elks46Login.vue
@@ -457,8 +457,7 @@ function handleReset() {
             </div>
 
             <p class="hint">
-              In 46elks: Numbers -> select number -> set <code>voice_start</code> to the JSON or URL
-              above.
+              In 46elks: Numbers -> select number -> set <code>voice_start</code> to the URL above.
             </p>
 
             <p class="hint" v-if="copyStatus">{{ copyStatus }}</p>


### PR DESCRIPTION
## What
- Replace outdated 'JSON or URL' wording with 'URL' in the 46elks voice_start helper text.