### PR TITLE
⚡ Optimize AMI Agent login queue lookups

### DIFF
--- a/src/composables/useAmiAgentLogin.ts
+++ b/src/composables/useAmiAgentLogin.ts
@@ -450,6 +450,9 @@ export function useAmiAgentLogin(
         throw new Error(`Invalid queue name(s): ${invalidQueues.join(', ')}`)
       }
 
+      // Use a Map for O(1) lookups during the loop
+      const queueMap = new Map(session.value.queues.map((q) => [q.queue, q]))
+
       for (const queue of queuesToJoin) {
         const rawPenalty =
           loginOptions.penalties?.[queue] ?? loginOptions.defaultPenalty ?? config.defaultPenalty
@@ -461,13 +464,13 @@ export function useAmiAgentLogin(
         })
 
         // Update local state
-        const existingQueue = session.value.queues.find((q) => q.queue === queue)
+        const existingQueue = queueMap.get(queue)
         if (existingQueue) {
           existingQueue.isMember = true
           existingQueue.penalty = penalty
           existingQueue.loginTime = Math.floor(Date.now() / 1000)
         } else {
-          session.value.queues.push({
+          const newQueue = {
             queue,
             interface: config.interface,
             isMember: true,
@@ -478,7 +481,9 @@ export function useAmiAgentLogin(
             lastCall: 0,
             loginTime: Math.floor(Date.now() / 1000),
             inCall: false,
-          })
+          }
+          session.value.queues.push(newQueue)
+          queueMap.set(queue, newQueue)
         }
 
         config.onQueueChange?.(queue, true)
@@ -521,11 +526,14 @@ export function useAmiAgentLogin(
         ? logoutOptions.queues
         : session.value.queues.filter((q) => q.isMember).map((q) => q.queue)
 
+      // Use a Map for O(1) lookups during the loop
+      const queueMap = new Map(session.value.queues.map((q) => [q.queue, q]))
+
       for (const queue of queuesToLeave) {
         await client.queueRemove(queue, config.interface)
 
         // Update local state
-        const queueMembership = session.value.queues.find((q) => q.queue === queue)
+        const queueMembership = queueMap.get(queue)
         if (queueMembership) {
           queueMembership.isMember = false
         }
@@ -578,11 +586,14 @@ export function useAmiAgentLogin(
         ? pauseOptions.queues
         : session.value.queues.filter((q) => q.isMember).map((q) => q.queue)
 
+      // Use a Map for O(1) lookups during the loop
+      const queueMap = new Map(session.value.queues.map((q) => [q.queue, q]))
+
       for (const queue of queuesToPause) {
         await client.queuePause(queue, config.interface, true, pauseOptions.reason)
 
         // Update local state
-        const queueMembership = session.value.queues.find((q) => q.queue === queue)
+        const queueMembership = queueMap.get(queue)
         if (queueMembership) {
           queueMembership.isPaused = true
           queueMembership.pauseReason = pauseOptions.reason
@@ -635,11 +646,14 @@ export function useAmiAgentLogin(
         ? queues
         : session.value.queues.filter((q) => q.isMember && q.isPaused).map((q) => q.queue)
 
+      // Use a Map for O(1) lookups during the loop
+      const queueMap = new Map(session.value.queues.map((q) => [q.queue, q]))
+
       for (const queue of queuesToUnpause) {
         await client.queuePause(queue, config.interface, false)
 
         // Update local state
-        const queueMembership = session.value.queues.find((q) => q.queue === queue)
+        const queueMembership = queueMap.get(queue)
         if (queueMembership) {
           queueMembership.isPaused = false
           queueMembership.pauseReason = undefined

--- a/tests/performance/benchmarks/useAmiAgentLogin.bench.ts
+++ b/tests/performance/benchmarks/useAmiAgentLogin.bench.ts
@@ -1,0 +1,50 @@
+import { bench, describe, beforeEach, vi } from 'vitest'
+import { useAmiAgentLogin } from '@/composables/useAmiAgentLogin'
+import type { AmiClient } from '@/core/AmiClient'
+import { createMockAmiClient, createAmiSuccessResponse } from '../../unit/utils/mockFactories'
+
+describe('useAmiAgentLogin Performance', () => {
+  let mockClient: any
+  const queueCount = 100
+  const queues = Array.from({ length: queueCount }, (_, i) => `queue_${i}`)
+
+  const defaultOptions = {
+    agentId: 'agent1001',
+    interface: 'PJSIP/1001',
+    name: 'Test Agent',
+    availableQueues: queues,
+    defaultQueues: queues,
+    persistState: false,
+  }
+
+  beforeEach(() => {
+    mockClient = createMockAmiClient()
+    mockClient.queueAdd = vi.fn().mockResolvedValue(createAmiSuccessResponse())
+    mockClient.queueRemove = vi.fn().mockResolvedValue(createAmiSuccessResponse())
+    mockClient.queuePause = vi.fn().mockResolvedValue(createAmiSuccessResponse())
+  })
+
+  bench(`login to ${queueCount} queues`, async () => {
+    const { login } = useAmiAgentLogin(mockClient as unknown as AmiClient, defaultOptions)
+    await login({ queues })
+  })
+
+  bench(`logout from ${queueCount} queues`, async () => {
+    const { login, logout } = useAmiAgentLogin(mockClient as unknown as AmiClient, defaultOptions)
+    await login({ queues })
+    await logout({ queues })
+  })
+
+  bench(`pause in ${queueCount} queues`, async () => {
+    const { login, pause } = useAmiAgentLogin(mockClient as unknown as AmiClient, defaultOptions)
+    await login({ queues })
+    await pause({ queues, reason: 'Break' })
+  })
+
+  bench(`unpause in ${queueCount} queues`, async () => {
+    const { login, pause, unpause } = useAmiAgentLogin(mockClient as unknown as AmiClient, defaultOptions)
+    await login({ queues })
+    await pause({ queues, reason: 'Break' })
+    await unpause(queues)
+  })
+})


### PR DESCRIPTION
💡 **What:** Replaced repetitive `.find()` array searches with O(1) `Map` lookups in the `useAmiAgentLogin` composable's `login`, `logout`, `pause`, and `unpause` methods.

🎯 **Why:** To improve performance when processing multiple queues (e.g., during bulk login or logout), reducing the algorithmic complexity from $O(N \times M)$ to $O(N + M)$.

📊 **Measured Improvement:** Empirical measurement was impractical in the current environment due to lack of network access to install `node_modules`. However, the theoretical complexity improvement from $O(N^2)$ to $O(N)$ provides a clear and significant performance boost for operations involving large sets of queues. A new benchmark file `tests/performance/benchmarks/useAmiAgentLogin.bench.ts` has been added for future verification.

---
*PR created automatically by Jules for task [7674849252115925654](https://jules.google.com/task/7674849252115925654) started by @ironyh*