### PR TITLE
fix(e2e): increase job timeouts to prevent test cancellations

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   test:
-    timeout-minutes: 90
+    timeout-minutes: 180
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -123,7 +123,7 @@ jobs:
     # limitations with mobile browser automation (mockSIPServer + mobile viewport + Playwright).
     # Mobile tests run on main pushes and workflow_dispatch for release verification.
     if: github.event_name != 'pull_request'
-    timeout-minutes: 20
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

E2E tests (chromium/firefox/webkit) consistently run for ~89 minutes before getting cancelled, hitting the 90-minute timeout limit on the test job. This affected all PRs and main branch pushes.

Additionally, the test-mobile job had a 20-minute timeout but runs only on push events (not PRs) — this was also too tight.

## Changes

- test job: timeout-minutes 90 → 180
- test-mobile job: timeout-minutes 20 → 60

## Root Cause

The E2E suite has ~1340 tests (280+ per browser) run with only 2 CI workers, making each run take close to 90 minutes. The jobs were cancelled right at the wire (step ran for 88m53s before cancellation).

## Testing

A CI run on this branch will verify the increased timeouts allow the full test suite to complete.