### PR TITLE
docs(templates): link root CONTRIBUTING.md from starter READMEs

### DIFF
--- a/templates/basic-softphone/README.md
+++ b/templates/basic-softphone/README.md
@@ -2,6 +2,8 @@
 
 A production-ready softphone template with PrimeVue UI components, featuring a complete dialpad, call controls, call history, and audio device settings.
 
+> **Contributing / development:** See [`CONTRIBUTING.md`](../../CONTRIBUTING.md) in the repo root for the pnpm workspace install, the `smoke:templates` gate, and other cross-template guidance before filing a PR touching this starter.
+
 ## Features
 
 - Professional UI with PrimeVue components

--- a/templates/call-center/README.md
+++ b/templates/call-center/README.md
@@ -2,6 +2,8 @@
 
 A production-ready call center agent interface with PrimeVue UI, featuring agent dashboard, queue statistics, call controls, and supervisor capabilities.
 
+> **Contributing / development:** See [`CONTRIBUTING.md`](../../CONTRIBUTING.md) in the repo root for the pnpm workspace install, the `smoke:templates` gate, and other cross-template guidance before filing a PR touching this starter.
+
 ## Features
 
 - Agent login/logout/pause with queue management

--- a/templates/ivr-tester/README.md
+++ b/templates/ivr-tester/README.md
@@ -2,6 +2,8 @@
 
 Interactive Voice Response (IVR) testing tool built with VueSIP. Test and map IVR phone systems by making real calls and navigating menus with DTMF tones.
 
+> **Contributing / development:** See [`CONTRIBUTING.md`](../../CONTRIBUTING.md) in the repo root for the pnpm workspace install, the `smoke:templates` gate, and other cross-template guidance before filing a PR touching this starter.
+
 ## Features
 
 - **IVR Tree Visualization**: Build a visual tree as you navigate IVR menus

--- a/templates/minimal/README.md
+++ b/templates/minimal/README.md
@@ -2,6 +2,8 @@
 
 A minimal starter template demonstrating core VueSip functionality with a simple, clean interface.
 
+> **Contributing / development:** See [`CONTRIBUTING.md`](../../CONTRIBUTING.md) in the repo root for the pnpm workspace install, the `smoke:templates` gate, and other cross-template guidance before filing a PR touching this starter.
+
 ## Features
 
 - SIP connection and registration

--- a/templates/pwa-softphone/README.md
+++ b/templates/pwa-softphone/README.md
@@ -2,6 +2,8 @@
 
 A production-ready Progressive Web App (PWA) softphone template built with Vue 3 and VueSIP. This template provides a mobile-first, installable softphone that can receive push notifications for incoming calls.
 
+> **Contributing / development:** See [`CONTRIBUTING.md`](../../CONTRIBUTING.md) in the repo root for the pnpm workspace install, the `smoke:templates` gate, and other cross-template guidance before filing a PR touching this starter.
+
 ## Features
 
 - **PWA Support**: Installable on mobile and desktop devices

--- a/templates/video-room/README.md
+++ b/templates/video-room/README.md
@@ -2,6 +2,8 @@
 
 A multi-participant video conferencing application template built with Vue 3 and VueSIP.
 
+> **Contributing / development:** See [`CONTRIBUTING.md`](../../CONTRIBUTING.md) in the repo root for the pnpm workspace install, the `smoke:templates` gate, and other cross-template guidance before filing a PR touching this starter.
+
 ## Features
 
 - **Dynamic Video Grid** - Responsive grid layout that adapts to participant count (1x1, 2x2, 3x3, etc.)


### PR DESCRIPTION
Closes #221.

## Summary

Each template under `templates/` has its own README, but none of them referenced the repo-root [`CONTRIBUTING.md`](../../CONTRIBUTING.md). A new contributor landing on (say) `templates/basic-softphone/README.md` had no obvious way to discover the pnpm workspace install, the `smoke:templates` gate, or any of the cross-template guidance before filing a PR.

## Change

A one-line blockquote near the top of each of the 6 template READMEs, placed right after the tagline line:

```md
> **Contributing / development:** See [`CONTRIBUTING.md`](../../CONTRIBUTING.md) in the repo root for the pnpm workspace install, the `smoke:templates` gate, and other cross-template guidance before filing a PR touching this starter.
```

Applied to:

- `templates/basic-softphone/README.md`
- `templates/call-center/README.md`
- `templates/ivr-tester/README.md`
- `templates/minimal/README.md`
- `templates/pwa-softphone/README.md`
- `templates/video-room/README.md`

Relative link verified: from any `templates/<name>/README.md`, `../../CONTRIBUTING.md` resolves to the repo root guide.

Docs only. +12 / -0.