### PR TITLE
perf(recording): stop active recordings concurrently on uninstall

### DIFF
--- a/src/plugins/RecordingPlugin.ts
+++ b/src/plugins/RecordingPlugin.ts
@@ -481,14 +481,16 @@ export class RecordingPlugin implements Plugin<RecordingPluginConfig> {
   async uninstall(_context: PluginContext): Promise<void> {
     logger.info('Uninstalling recording plugin')
 
-    // Stop all active recordings
-    for (const [callId] of this.activeRecordings) {
-      try {
-        await this.stopRecording(callId)
-      } catch (error) {
-        logger.error(`Failed to stop recording for call ${callId}`, error)
-      }
-    }
+    // Stop all active recordings concurrently (independent operations)
+    await Promise.allSettled(
+      Array.from(this.activeRecordings.keys()).map(async (callId) => {
+        try {
+          await this.stopRecording(callId)
+        } catch (error) {
+          logger.error(`Failed to stop recording for call ${callId}`, error)
+        }
+      })
+    )
 
     // Clear all recording blobs from memory
     for (const [recordingId] of this.recordings) {


### PR DESCRIPTION
## Summary

Replaces the sequential `for ... await` loop in `RecordingPlugin.uninstall()` with `Promise.allSettled`, so active recordings are stopped in parallel during teardown.

## Why

Stopping recordings is an independent per-call operation. The old serial loop waited for each `stopRecording()` to resolve before starting the next, adding unnecessary latency when multiple calls are active at uninstall time.

## Behavior preserved

- Per-call errors are still caught and logged individually.
- `uninstall()` still never rejects — `Promise.allSettled` guarantees this explicitly.

## Verification

- `vue-tsc --noEmit`: clean
- RecordingPlugin unit tests: **144/144 passing** (14 files), including:
  - `should stop all recordings on uninstall` (3 concurrent calls → all stopped)
  - `should handle uninstall errors gracefully` (a thrown `stop()` does not reject uninstall)

## Context

Recreates the legitimate ~12-line change from #229, which was closed because it bundled this optimization with 52 files of formatting noise. This PR contains only the recording-plugin change.