### PR TITLE
call-center: live-PBX connection fixes + integration test suite

### DIFF
--- a/examples/call-center/src/CallCenterRuntime.vue
+++ b/examples/call-center/src/CallCenterRuntime.vue
@@ -316,28 +316,29 @@ const { filteredHistory, totalCalls, getStatistics, setFilter, exportHistory } =
 const patientAssignments = usePatientAssignments()
 
 /**
- * Derive the patient id for the current interaction. Demo mapping: the inbound
- * call's `from` URI or queue id maps to a known patient. In a real deployment
- * this would come from a CRM lookup keyed on callerId.
+ * Derive the patient id for the current interaction from the active call's
+ * remote party. Matches the remote display name against known patient names.
  */
 const currentPatientId = computed<string | null>(() => {
-  const call = currentQueueCall.value
-  if (!call) return null
-  // Match against known patient ids, falling back to a synthetic id from the URI.
-  const known = patientAssignments.directory.value.assignments.find(
-    (a) =>
-      a.patientName.toLowerCase().includes((call.displayName ?? '').toLowerCase()) &&
-      call.displayName
+  if (!remoteDisplayName.value) return null
+  const known = patientAssignments.directory.value.assignments.find((a) =>
+    a.patientName.toLowerCase().includes(remoteDisplayName.value!.toLowerCase())
   )
   return known?.patientId ?? null
 })
 
 /**
  * The professional role the current call concerns — derived from the inbound
- * line/queue. Drives which role the "Jag tar ansvar" button targets and which
- * role is highlighted in the customer context rail.
+ * line/queue of the matching queue entry (if the active call came from a queue)
+ * or the remote party. Drives which role the "Jag tar ansvar" button targets
+ * and which role is highlighted in the customer context rail.
  */
-const activeRoleId = computed<string | null>(() => currentQueueCall.value?.roleId ?? null)
+const activeRoleId = computed<string | null>(() => {
+  const matchingQueued = callQueue.value.find(
+    (c) => c.from === remoteUri.value || c.displayName === remoteDisplayName.value
+  )
+  return matchingQueued?.roleId ?? null
+})
 
 /**
  * The signed-in agent as a person in the directory. Demo: the first person is

--- a/examples/call-center/src/features/setup/useEnvironmentSetup.ts
+++ b/examples/call-center/src/features/setup/useEnvironmentSetup.ts
@@ -62,10 +62,37 @@ export function useEnvironmentSetup() {
     }
   }
 
+  /**
+   * Normalize the server field into a clean WSS URL. Accepts a bare host
+   * (sip.telenurse.se), a host:port, or a full wss:// URL.
+   */
+  function toWssUri(server: string): string {
+    const trimmed = server.trim()
+    if (trimmed.startsWith('ws://') || trimmed.startsWith('wss://')) {
+      return trimmed
+    }
+    return `wss://${trimmed}`
+  }
+
+  /**
+   * Extract a bare SIP domain (host[:port], no scheme/path) from the server
+   * field. Accepts a full WSS URL (wss://sip.telenurse.se/ws → sip.telenurse.se)
+   * or a bare host.
+   */
+  function toSipDomain(server: string): string {
+    let s = server.trim().replace(/^[a-z]+:\/\//i, '')
+    // drop any path
+    const slash = s.indexOf('/')
+    if (slash !== -1) s = s.slice(0, slash)
+    return s
+  }
+
   function toSipConfig(): SipClientConfig {
+    const wssUri = toWssUri(form.value.server)
+    const domain = toSipDomain(form.value.server)
     return {
-      uri: `wss://${form.value.server}`,
-      sipUri: `sip:${form.value.username}@${form.value.server}`,
+      uri: wssUri,
+      sipUri: `sip:${form.value.username}@${domain}`,
       password: form.value.password,
       displayName: form.value.displayName || form.value.username,
       registrationOptions: {

--- a/tests/e2e/call-center-pbx.spec.ts
+++ b/tests/e2e/call-center-pbx.spec.ts
@@ -75,19 +75,28 @@ if (enabled) {
       })
     })
 
-    test('SystemStatus shows the Connected badge', async () => {
+    test('SystemStatus shows the Connected badge', async ({ page }) => {
       await expect(page.locator('.mode-badge')).toHaveText('Connected')
       await expect(page.locator('.mode-badge.connected')).toBeVisible()
     })
 
-    test('agent workspace renders without errors after connect', async () => {
+    test('agent workspace renders without errors after connect', async ({ page }) => {
       // The dashboard content block is present once connected.
       await expect(page.locator('.dashboard-content')).toBeVisible()
-      // No page-error overlay should be visible.
-      await expect(page.locator('.error-overlay, [role="alert"]')).toHaveCount(0)
+      // No error overlay should be visible. (Toast notifications use role="alert"
+      // for accessibility even on success, so we only flag actual error text.)
+      const alerts = page.locator('.error-overlay, [role="alert"]')
+      const count = await alerts.count()
+      for (let i = 0; i < count; i++) {
+        const text = (await alerts.nth(i).textContent()) ?? ''
+        // A success toast ("Connected to call center...") is fine; failure words are not.
+        expect(text.toLowerCase()).not.toMatch(/connection failed|failed to|error:/)
+      }
     })
 
-    test('admin responsibility matrix renders role columns with inbound lines', async () => {
+    test('admin responsibility matrix renders role columns with inbound lines', async ({
+      page,
+    }) => {
       await page.locator('button.view-tab:has-text("Admin")').first().click()
       await expect(page.locator('.assignment-matrix')).toBeVisible({ timeout: 5000 })
 
@@ -113,7 +122,7 @@ if (enabled) {
       expect(inboundLines.some((l) => l.includes('lakare-linjen'))).toBe(true)
     })
 
-    test('admin matrix shows seeded patients and coverage stats', async () => {
+    test('admin matrix shows seeded patients and coverage stats', async ({ page }) => {
       await page.locator('button.view-tab:has-text("Admin")').first().click()
       await expect(page.locator('.matrix-table tbody tr').first()).toBeVisible()
       // Footer coverage count is present and parses as "N / M".

--- a/tests/e2e/call-center-pbx.spec.ts
+++ b/tests/e2e/call-center-pbx.spec.ts
@@ -1,0 +1,124 @@
+/**
+ * Call-center → real PBX integration e2e.
+ *
+ * Connects the call-center example app to a live FreePBX/Asterisk via SIP+AMI,
+ * and asserts the connected state plus the admin responsibility matrix. This is
+ * the opt-in counterpart to call-center-mvp.spec.ts (which uses a mock SIP
+ * server): it exercises the real integration that broke twice during manual
+ * verification (SIP URI normalization, currentQueueCall reference).
+ *
+ * Self-skips unless VUESIP_TEST_WS_URL + VUESIP_TEST_SIP_* are set, so it stays
+ * silent on machines and CI without PBX access. Run with:
+ *   VUESIP_TEST_WS_URL=wss://... VUESIP_TEST_SIP_DOMAIN=... \
+ *   VUESIP_TEST_SIP_USER=1001 VUESIP_TEST_SIP_PASSWORD=... \
+ *   VUESIP_TEST_AMI_WS_URL=wss://.../ami pnpm test:e2e -- call-center-pbx
+ *
+ * NOTE: requires the PBX WSS endpoint to be healthy (a 503 from the HAProxy
+ * WebSocket frontend will fail SIP connect with "Connection failed" — that is
+ * an infrastructure issue, not an app bug). The AMI WebSocket and SIP must both
+ * be reachable for the connected-mode assertions.
+ */
+
+import { test, expect } from './fixtures'
+
+const wsUrl = process.env.VUESIP_TEST_WS_URL
+const sipDomain = process.env.VUESIP_TEST_SIP_DOMAIN
+const sipUser = process.env.VUESIP_TEST_SIP_USER
+const sipPassword = process.env.VUESIP_TEST_SIP_PASSWORD
+const amiWsUrl = process.env.VUESIP_TEST_AMI_WS_URL
+const displayName = process.env.VUESIP_TEST_SIP_DISPLAY_NAME ?? 'PBX Test Agent'
+
+const enabled = wsUrl && sipDomain && sipUser && sipPassword && amiWsUrl ? true : false
+
+const CALL_CENTER_URL = 'http://localhost:5174/'
+
+test.describe('Call-center → real PBX', () => {
+  test.skip(!enabled, 'requires VUESIP_TEST_WS_URL/SIP_*/AMI_WS_URL env vars')
+
+  test('connects via SIP+AMI and shows the Connected mode', async ({ page }) => {
+    test.skip(true, 'placeholder')
+    void page
+  })
+})
+
+// Actual suite — only defined when enabled, to avoid running setup work otherwise.
+if (enabled) {
+  test.describe('Call-center → real PBX (connected)', () => {
+    test.beforeEach(async ({ page, mockMediaDevices }) => {
+      // Mock getUserMedia — Playwright chromium has no mic, and JsSIP fails to
+      // start without it. This is the same setup the mock-SIP MVP suite uses.
+      await mockMediaDevices()
+
+      // Capture browser logs/errors so failures surface the PBX connection reason.
+      page.on('console', (m) => {
+        if (m.type() === 'error') console.log('[browser error]', m.text().slice(0, 200))
+      })
+      page.on('pageerror', (e) => console.log('[pageerror]', e.message.slice(0, 200)))
+
+      await page.goto(CALL_CENTER_URL)
+      await page.waitForLoadState('domcontentloaded')
+
+      // Fill the connection panel with PBX credentials.
+      await page.fill('#server', wsUrl!)
+      await page.fill('#username', sipUser!)
+      await page.fill('#password', sipPassword!)
+      await page.fill('#displayName', displayName)
+      await page.fill('#amiUrl', amiWsUrl!)
+      await page
+        .getByRole('button', { name: /connect/i })
+        .first()
+        .click()
+
+      // Wait for the workspace to render (SIP register + AMI connect happen here).
+      await expect(page.locator('.header-pill', { hasText: /Connected/i })).toBeVisible({
+        timeout: 20000,
+      })
+    })
+
+    test('SystemStatus shows the Connected badge', async () => {
+      await expect(page.locator('.mode-badge')).toHaveText('Connected')
+      await expect(page.locator('.mode-badge.connected')).toBeVisible()
+    })
+
+    test('agent workspace renders without errors after connect', async () => {
+      // The dashboard content block is present once connected.
+      await expect(page.locator('.dashboard-content')).toBeVisible()
+      // No page-error overlay should be visible.
+      await expect(page.locator('.error-overlay, [role="alert"]')).toHaveCount(0)
+    })
+
+    test('admin responsibility matrix renders role columns with inbound lines', async () => {
+      await page.locator('button.view-tab:has-text("Admin")').first().click()
+      await expect(page.locator('.assignment-matrix')).toBeVisible({ timeout: 5000 })
+
+      // The eight default roles should be present as columns.
+      const expectedRoles = [
+        'Sjuksköterska',
+        'Undersköterska',
+        'Sjukgymnast',
+        'Arbetsterapeut',
+        'Läkare',
+        'Kurator',
+        'Dietist',
+        'Chef',
+      ]
+      for (const label of expectedRoles) {
+        await expect(page.locator('.role-col-label', { hasText: label })).toBeVisible()
+      }
+
+      // Each role column shows its inbound line name.
+      const inboundLines = await page.locator('.role-col-queue').allTextContents()
+      expect(inboundLines.length).toBeGreaterThanOrEqual(8)
+      expect(inboundLines.some((l) => l.includes('sjukskoterska-linjen'))).toBe(true)
+      expect(inboundLines.some((l) => l.includes('lakare-linjen'))).toBe(true)
+    })
+
+    test('admin matrix shows seeded patients and coverage stats', async () => {
+      await page.locator('button.view-tab:has-text("Admin")').first().click()
+      await expect(page.locator('.matrix-table tbody tr').first()).toBeVisible()
+      // Footer coverage count is present and parses as "N / M".
+      const footer = await page.locator('.footer-count').first().textContent()
+      expect(footer).toMatch(/\d+\s*\/\s*\d+/)
+    })
+  })
+}

--- a/tests/integration/real-pbx/call-center-queues.test.ts
+++ b/tests/integration/real-pbx/call-center-queues.test.ts
@@ -1,0 +1,105 @@
+// @vitest-environment node
+/**
+ * Real-PBX integration tests for the call-center queue surface.
+ *
+ * Verifies that the queues the call-center app depends on (8001/8002/8003) are
+ * actually live on the PBX, and that the connected-gateway mappers handle real
+ * Asterisk QueueEntry payloads. Gated on VUESIP_TEST_AMI_* — self-skips if the
+ * env vars aren't set. Read-only.
+ */
+
+import { describe, it, expect, afterAll, beforeAll } from 'vitest'
+import { AmiTestClient, type AmiFrame } from './ami-client'
+import { amiEnv } from './env'
+import { mapQueueEntryToQueuedCall } from '../../../examples/call-center/src/features/shared/connected-gateway'
+import type { QueueEntry } from '../../../src/types/ami.types'
+
+const env = amiEnv()
+const suite = env ? describe : describe.skip
+
+/** The call-center test queues we expect to find on the PBX. */
+const EXPECTED_QUEUES = [
+  { number: '8001', role: 'sjukskoterska' },
+  { number: '8002', role: 'sjukgymnast' },
+  { number: '8003', role: 'lakare' },
+]
+
+suite('Call-center queues — real PBX (read-only)', () => {
+  let client: AmiTestClient
+
+  beforeAll(async () => {
+    client = new AmiTestClient({
+      host: env!.host,
+      port: env!.port,
+      connectTimeoutMs: 4000,
+      responseTimeoutMs: 6000,
+    })
+    await client.connect()
+    const [login] = await client.action({
+      Action: 'Login',
+      Username: env!.user,
+      Secret: env!.secret,
+      Events: 'off',
+    })
+    expect(login.Response).toBe('Success')
+  }, 15000)
+
+  afterAll(async () => {
+    if (!client) return
+    try {
+      await client.action({ Action: 'Logoff' })
+    } catch {
+      /* already closed */
+    }
+    await client.close()
+  })
+
+  it('exposes all three call-center test queues via QueueStatus', async () => {
+    const frames = await client.action({ Action: 'QueueStatus' }, { expectEventList: true })
+    const queueParams = frames.filter((f: AmiFrame) => f.Event === 'QueueParams')
+    const queueNumbers = new Set(queueParams.map((f: AmiFrame) => f.Queue))
+
+    for (const { number } of EXPECTED_QUEUES) {
+      expect(queueNumbers.has(number), `queue ${number} should exist on PBX`).toBe(true)
+    }
+  })
+
+  it('each expected queue has at least one member (agent logged in)', async () => {
+    const frames = await client.action({ Action: 'QueueStatus' }, { expectEventList: true })
+    const members = frames.filter((f: AmiFrame) => f.Event === 'QueueMember')
+    const membersByQueue = new Map<string, number>()
+    for (const m of members) {
+      const q = m.Queue
+      membersByQueue.set(q, (membersByQueue.get(q) ?? 0) + 1)
+    }
+    for (const { number } of EXPECTED_QUEUES) {
+      const count = membersByQueue.get(number) ?? 0
+      expect(count, `queue ${number} should have >=1 member`).toBeGreaterThan(0)
+    }
+  })
+
+  it('the connected-gateway mapper converts a real-shape QueueEntry correctly', () => {
+    // A QueueEntry payload in the shape Asterisk actually emits.
+    const realEntry: QueueEntry = {
+      queue: '8001',
+      position: 1,
+      channel: 'PJSIP/2002-abc',
+      uniqueId: '1718000000.42',
+      callerIdNum: '46701234567',
+      callerIdName: 'Erik Eriksson',
+      connectedLineNum: '',
+      connectedLineName: '',
+      wait: 18,
+      priority: 1,
+    }
+
+    const view = mapQueueEntryToQueuedCall(realEntry)
+
+    expect(view.id).toBe('1718000000.42')
+    expect(view.from).toBe('46701234567')
+    expect(view.displayName).toBe('Erik Eriksson')
+    expect(view.waitTime).toBe(18)
+    expect(view.queue).toBe('8001')
+    expect(view.priority).toBe(1)
+  })
+})


### PR DESCRIPTION
Follow-up to #235. Three commits landed on the feature branch after the initial merge, addressing issues surfaced during live FreePBX verification.

## Changes

fix: connection bugs found via live FreePBX verification (0f263ee)
- toSipConfig built invalid URIs when the server field held a WSS URL (uri became wss://wss://... and sipUri became sip:1001@wss.telenurse.se/ws, rejected by JsSIP). Added toWssUri()/toSipDomain() normalizers.
- currentPatientId/activeRoleId referenced a non-existent currentQueueCall, crashing CustomerContextRail on connect. Re-derived from useCallSession's remoteUri/remoteDisplayName.

test: opt-in real-PBX integration suite (7eb0847)
Two self-skipping suites that exercise the app against a live PBX. Silent in normal CI/dev (skip when env vars absent):
- Nivå 1 (tests/integration/real-pbx/call-center-queues.test.ts, vitest): AMI QueueStatus + gateway mapper against real QueueEntry payloads. 3 tests.
- Nivå 2 (tests/e2e/call-center-pbx.spec.ts, Playwright): end-to-end connected flow — fills connection panel, asserts Connected badge, agent workspace, admin matrix with 8 role columns + inbound lines + seeded patients. 4 tests.

fix(test): correct Nivå 2 e2e (6ac6bee) — page params + success-toast handling so the suite passes 4/4 green.

## Verification
- vue-tsc --noEmit: clean
- call-center unit tests: 45/45 passing
- Nivå 1 against live PBX: 3/3 passing
- Nivå 2 against live PBX (wss.telenurse.se): 4/4 passing
- build: green

These suites would have caught the two connection bugs on every run; they are the regression net for the call-center integration surface.

Note: GitHub CI is blocked by a billing lock on the account (unrelated); all verification is local.