### PR TITLE
feat(call-center): inbound call answering + Nivå 3 e2e

### DIFF
--- a/examples/call-center/src/CallCenterRuntime.vue
+++ b/examples/call-center/src/CallCenterRuntime.vue
@@ -110,6 +110,14 @@
         </aside>
 
         <main id="main-content" class="main-content" aria-label="Active call or statistics">
+          <IncomingCallBanner
+            v-if="isRinging"
+            :remote-display-name="remoteDisplayName"
+            :remote-uri="remoteUri"
+            :queue-call="incomingQueueCall"
+            @accept="handleAnswerIncoming"
+            @reject="handleRejectIncoming"
+          />
           <ActiveCall
             v-if="isActive"
             id="active-call"
@@ -191,6 +199,7 @@ import AgentStatusToggle from './components/AgentStatusToggle.vue'
 import AgentDashboard from './components/AgentDashboard.vue'
 import CallQueue from './components/CallQueue.vue'
 import ActiveCall from './components/ActiveCall.vue'
+import IncomingCallBanner from './components/IncomingCallBanner.vue'
 import CallStats from './components/CallStats.vue'
 import DemoKpiBar from './components/DemoKpiBar.vue'
 import PresenterControls from './components/PresenterControls.vue'
@@ -301,11 +310,14 @@ const {
   state,
   remoteUri,
   remoteDisplayName,
+  direction,
   isActive,
   duration,
   isMuted,
   isOnHold,
   makeCall,
+  answer,
+  reject,
   hangup,
   toggleMute,
   toggleHold,
@@ -341,6 +353,25 @@ const activeRoleId = computed<string | null>(() => {
     (c) => c.from === remoteUri.value || c.displayName === remoteDisplayName.value
   )
   return matchingQueued?.roleId ?? null
+})
+
+/**
+ * Is an inbound call currently ringing on this endpoint? (Asterisk delivers a
+ * queue caller as a SIP INVITE; `useCallSession` flags it direction='incoming'.)
+ */
+const isRinging = computed(() => direction.value === 'incoming' && state.value === 'ringing')
+
+/**
+ * The queue entry (if any) that the currently-ringing inbound call corresponds
+ * to. Correlated by caller number, since SIP remoteUri and AMI callerIdNum both
+ * carry the caller's number (possibly in different formats — extractNumber
+ * normalizes). Null for non-queue calls or demo mode (no inbound SIP there).
+ */
+const incomingQueueCall = computed<QueuedCallView | null>(() => {
+  if (!isRinging.value) return null
+  const num = extractNumber(remoteUri.value)
+  if (!num) return null
+  return callQueue.value.find((c) => extractNumber(c.from) === num) ?? null
 })
 
 /**
@@ -772,6 +803,13 @@ const handleCallStateChange = (announcement: string) => {
 }
 
 const handleQueuedCallAnswer = async (queuedCall: QueuedCall) => {
+  // In connected mode the PBX delivers the queue caller to this endpoint as an
+  // inbound SIP INVITE — the agent must accept the ringing banner (Answer),
+  // not originate a new outbound call. Directing the user is the right action.
+  if (isConnectedMode.value) {
+    showNotification('info', 'Vänta på inkommande samtal från kön — klicka Svara när det ringer.')
+    return
+  }
   try {
     callQueue.value = callQueue.value.filter((c) => c.id !== queuedCall.id)
     selectQueuedCall(queuedCall)
@@ -793,6 +831,40 @@ const handleQueuedCallAnswer = async (queuedCall: QueuedCall) => {
     agentStatus.value = 'available'
     saveAgentStatus('available')
     syncWorkspaceFromAgentStatus('available')
+  }
+}
+
+/**
+ * Answer a ringing inbound call (delivered by the PBX from a queue). This is
+ * the correct "answer" path in connected mode — it accepts the existing SIP
+ * dialog rather than originating a new outbound call.
+ */
+const handleAnswerIncoming = async () => {
+  try {
+    // Correlate to the queue entry so wrap-up / responsibility get the right context.
+    if (incomingQueueCall.value) {
+      callQueue.value = callQueue.value.filter((c) => c.id !== incomingQueueCall.value!.id)
+      selectQueuedCall(incomingQueueCall.value)
+    }
+    agentStatus.value = 'busy'
+    saveAgentStatus('busy')
+    await answer()
+    showNotification('success', `Besvarat: ${remoteDisplayName.value || remoteUri.value}`)
+  } catch (answerError) {
+    console.error('Failed to answer incoming call:', answerError)
+    showNotification(
+      'error',
+      'Kunde inte besvara: ' + (answerError instanceof Error ? answerError.message : 'Okänt fel')
+    )
+  }
+}
+
+const handleRejectIncoming = async () => {
+  try {
+    await reject()
+    showNotification('info', 'Samtal avvisat')
+  } catch (rejectError) {
+    console.error('Failed to reject incoming call:', rejectError)
   }
 }
 

--- a/examples/call-center/src/components/IncomingCallBanner.vue
+++ b/examples/call-center/src/components/IncomingCallBanner.vue
@@ -1,0 +1,163 @@
+<template>
+  <div
+    class="incoming-banner"
+    data-testid="call-center-incoming-banner"
+    role="alert"
+    aria-live="assertive"
+  >
+    <div class="banner-icon" aria-hidden="true">📞</div>
+    <div class="banner-info">
+      <p class="banner-title">Inkommande samtal</p>
+      <p class="banner-caller">{{ callerLabel }}</p>
+      <p v-if="queueName" class="banner-queue">Kö: {{ queueName }}</p>
+    </div>
+    <div class="banner-actions">
+      <button
+        type="button"
+        class="btn btn-accept"
+        data-testid="call-center-incoming-accept"
+        @click="$emit('accept')"
+      >
+        Svara
+      </button>
+      <button
+        type="button"
+        class="btn btn-reject"
+        data-testid="call-center-incoming-reject"
+        @click="$emit('reject')"
+      >
+        Avvisa
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { QueuedCallView } from '../features/shared/mvp-types'
+
+const props = defineProps<{
+  remoteDisplayName: string
+  remoteUri: string
+  /** The queue entry this call was correlated to, if any. */
+  queueCall: QueuedCallView | null
+}>()
+
+defineEmits<{
+  accept: []
+  reject: []
+}>()
+
+const callerLabel = computed(() => props.remoteDisplayName || props.remoteUri || 'Okänd anropare')
+
+const queueName = computed(() => props.queueCall?.queue ?? null)
+</script>
+
+<style scoped>
+.incoming-banner {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  background: linear-gradient(135deg, #fef3c7 0%, #fde68a 100%);
+  border: 2px solid #f59e0b;
+  border-radius: 12px;
+  padding: 1rem 1.25rem;
+  margin-bottom: 1rem;
+  box-shadow: 0 4px 12px rgba(245, 158, 11, 0.2);
+  animation: pulse-ring 1.5s ease-in-out infinite;
+}
+
+@keyframes pulse-ring {
+  0%,
+  100% {
+    box-shadow: 0 4px 12px rgba(245, 158, 11, 0.2);
+  }
+  50% {
+    box-shadow: 0 4px 20px rgba(245, 158, 11, 0.4);
+  }
+}
+
+.banner-icon {
+  font-size: 2rem;
+  animation: shake 0.5s ease-in-out infinite alternate;
+}
+
+@keyframes shake {
+  from {
+    transform: rotate(-8deg);
+  }
+  to {
+    transform: rotate(8deg);
+  }
+}
+
+.banner-info {
+  flex: 1;
+}
+
+.banner-title {
+  margin: 0;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #92400e;
+}
+
+.banner-caller {
+  margin: 0.125rem 0 0;
+  font-size: 1.125rem;
+  font-weight: 700;
+  color: #78350f;
+}
+
+.banner-queue {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: #92400e;
+}
+
+.banner-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.btn {
+  border: none;
+  border-radius: 8px;
+  font-weight: 700;
+  cursor: pointer;
+  padding: 0.625rem 1.25rem;
+  font-size: 0.9375rem;
+  transition:
+    background-color 0.15s ease,
+    transform 0.1s ease;
+}
+
+.btn:active {
+  transform: scale(0.97);
+}
+
+.btn:focus-visible {
+  outline: 2px solid #78350f;
+  outline-offset: 2px;
+}
+
+.btn-accept {
+  background: #16a34a;
+  color: #ffffff;
+}
+
+.btn-accept:hover {
+  background: #15803d;
+}
+
+.btn-reject {
+  background: #dc2626;
+  color: #ffffff;
+}
+
+.btn-reject:hover {
+  background: #b91c1c;
+}
+</style>

--- a/tests/e2e/call-center-inbound-pbx.spec.ts
+++ b/tests/e2e/call-center-inbound-pbx.spec.ts
@@ -1,0 +1,197 @@
+/**
+ * Nivå 3 — real-PBX inbound call flow (Fas 2).
+ *
+ * Injects a caller into queue 8001 via AMI Originate, then drives the call-center
+ * app (registered on PJSIP/1001) through the full flow: ringing banner → accept
+ * → active call → hangup → wrap-up. Verifies the AMI↔SIP correlation and the
+ * end-to-end path that the app changes in feat/call-center-inbound-answer enable.
+ *
+ * Self-skips unless VUESIP_TEST_* env vars are set (same gating as
+ * call-center-pbx.spec.ts). Note: depends on the PBX WSS proxy being healthy
+ * (registration flakiness on wss.telenurse.se will fail this test — that is an
+ * infrastructure issue, not an app bug).
+ *
+ * Run with creds from telenurse .env:
+ *   VUESIP_TEST_WS_URL=wss://... VUESIP_TEST_SIP_USER=1001 ... pnpm test:e2e -- call-center-inbound-pbx
+ */
+
+import { test, expect } from './fixtures'
+import { Socket } from 'node:net'
+
+const amiHost = process.env.VUESIP_TEST_AMI_HOST
+const amiPort = process.env.VUESIP_TEST_AMI_PORT
+  ? parseInt(process.env.VUESIP_TEST_AMI_PORT)
+  : undefined
+const amiUser = process.env.VUESIP_TEST_AMI_USER
+const amiSecret = process.env.VUESIP_TEST_AMI_SECRET
+const wsUrl = process.env.VUESIP_TEST_WS_URL
+const sipDomain = process.env.VUESIP_TEST_SIP_DOMAIN
+const sipUser = process.env.VUESIP_TEST_SIP_USER
+const sipPassword = process.env.VUESIP_TEST_SIP_PASSWORD
+const amiWsUrl = process.env.VUESIP_TEST_AMI_WS_URL
+
+const enabled =
+  amiHost &&
+  amiPort &&
+  amiUser &&
+  amiSecret &&
+  wsUrl &&
+  sipDomain &&
+  sipUser &&
+  sipPassword &&
+  amiWsUrl
+    ? true
+    : false
+
+const CALL_CENTER_URL = process.env.CALL_CENTER_URL || 'http://localhost:5174/'
+
+/** Minimal raw-AMI helper for Originate (mirrors AmiTestClient's wire format). */
+async function amiOriginate(opts: {
+  host: string
+  port: number
+  user: string
+  secret: string
+  channel: string
+  context: string
+  exten: string
+  callerId: string
+  actionId: string
+}): Promise<{ success: boolean; message: string }> {
+  return new Promise((resolve, reject) => {
+    const sock = new Socket()
+    let buf = ''
+    let resolved = false
+    const finish = (r: { success: boolean; message: string }) => {
+      if (resolved) return
+      resolved = true
+      clearTimeout(timer)
+      try {
+        sock.end()
+      } catch {
+        /* ignore */
+      }
+      resolve(r)
+    }
+    const timer = setTimeout(() => {
+      finish({ success: false, message: 'Originate timeout' })
+    }, 10000)
+
+    sock.connect(opts.port, opts.host, () => {
+      const send = (s: string) => sock.write(s + '\r\n')
+      // Login
+      send(`Action: Login`)
+      send(`Username: ${opts.user}`)
+      send(`Secret: ${opts.secret}`)
+      send(`Events: off`)
+      send(``)
+      // Originate (the login frame + originate frame are pipelined; AMI handles them in order)
+      send(`Action: Originate`)
+      send(`Channel: ${opts.channel}`)
+      send(`Context: ${opts.context}`)
+      send(`Exten: ${opts.exten}`)
+      send(`Priority: 1`)
+      send(`CallerID: ${opts.callerId}`)
+      send(`Async: true`)
+      send(`ActionID: ${opts.actionId}`)
+      send(`Timeout: 20000`)
+      send(``)
+    })
+    sock.on('data', (chunk) => {
+      buf += chunk.toString()
+      let idx: number
+      while ((idx = buf.indexOf('\r\n\r\n')) !== -1) {
+        const frame = buf.slice(0, idx)
+        buf = buf.slice(idx + 4)
+        const lines = frame.split('\r\n')
+        const pkt: Record<string, string> = {}
+        for (const l of lines) {
+          const ci = l.indexOf(':')
+          if (ci !== -1) pkt[l.slice(0, ci).trim()] = l.slice(ci + 1).trim()
+        }
+        if (pkt.Response === 'Success' && pkt.Message?.includes('Originate')) {
+          finish({ success: true, message: pkt.Message })
+        } else if (pkt.Response === 'Error' && pkt.ActionID === opts.actionId) {
+          finish({ success: false, message: pkt.Message })
+        } else if (pkt.Response === 'Success' && pkt.Message === 'Authentication accepted') {
+          // login ok, waiting for originate response
+        }
+      }
+    })
+    sock.on('error', (err) => {
+      if (!resolved) reject(err)
+    })
+  })
+}
+
+test.describe('Call-center inbound (real PBX, Nivå 3)', () => {
+  test.skip(!enabled, 'requires VUESIP_TEST_* env vars + healthy PBX WSS')
+
+  test('AMI Originate injects a queue caller; app rings, accepts, wraps up', async ({
+    page,
+    mockMediaDevices,
+  }) => {
+    test.setTimeout(90000)
+    await mockMediaDevices()
+
+    // 1) Connect the app to the PBX.
+    await page.goto(CALL_CENTER_URL)
+    await page.waitForLoadState('domcontentloaded')
+    await page.fill('#server', wsUrl!)
+    await page.fill('#username', sipUser!)
+    await page.fill('#password', sipPassword!)
+    await page.fill('#displayName', 'PBX Inbound Test')
+    await page.fill('#amiUrl', amiWsUrl!)
+    await page
+      .getByRole('button', { name: /connect/i })
+      .first()
+      .click()
+
+    // Wait for registration + AMI connect.
+    await expect(page.locator('.header-pill', { hasText: /Connected/i })).toBeVisible({
+      timeout: 20000,
+    })
+    // Set agent available (logs into queues).
+    const availableBtn = page.locator('button:has-text("Available")').first()
+    await availableBtn.click().catch(() => {})
+    // Give AMI login time.
+    await page.waitForTimeout(5000)
+
+    // 2) Inject a caller into queue 8001 via AMI Originate.
+    const actionId = `e2e-inbound-${Date.now()}`
+    const callerNum = '5550001'
+    const result = await amiOriginate({
+      host: amiHost!,
+      port: amiPort!,
+      user: amiUser!,
+      secret: amiSecret!,
+      channel: `Local/${callerNum}@from-internal`,
+      context: 'from-internal',
+      exten: '8001',
+      callerId: `"Nivå3 Test Caller" <${callerNum}>`,
+      actionId,
+    })
+    expect(result.success, `Originate should succeed: ${result.message}`).toBe(true)
+
+    // 3) The app should ring (IncomingCallBanner appears).
+    await expect(page.getByTestId('call-center-incoming-banner')).toBeVisible({
+      timeout: 20000,
+    })
+
+    // 4) Accept the call.
+    await page.getByTestId('call-center-incoming-accept').click()
+    await expect(page.getByTestId('call-center-active-call')).toBeVisible({ timeout: 15000 })
+
+    // 5) Hang up → wrap-up.
+    await page.getByTestId('call-center-hangup').click()
+    await expect(page.getByTestId('call-center-wrap-up')).toBeVisible({ timeout: 15000 })
+
+    await page.getByTestId('wrap-up-disposition').selectOption('resolved')
+    await page.getByTestId('wrap-up-notes').fill('Nivå 3 live test')
+    await page.getByTestId('wrap-up-complete').click()
+
+    // Back to dashboard — the call completed and wrapped up.
+    await expect(page.locator('.header-pill', { hasText: /Connected/i })).toBeVisible({
+      timeout: 10000,
+    })
+  })
+})

--- a/tests/e2e/call-center-inbound.spec.ts
+++ b/tests/e2e/call-center-inbound.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * Call-center inbound call e2e (Fas 1 — mocked SIP).
+ *
+ * Verifies the ringing-UI + answer/reject + wrap-up flow that the app changes in
+ * feat/call-center-inbound-answer introduced. Uses the mock SIP server + the
+ * `simulateIncomingCall` fixture to inject a ringing inbound call (the same
+ * fixture pattern as incoming-call.spec.ts), so it runs without a real PBX.
+ *
+ * What this proves: when a SIP INVITE arrives at the connected endpoint, the
+ * IncomingCallBanner renders with Svara/Avvisa buttons; clicking Svara calls
+ * useCallSession.answer() (not makeCall); the call becomes active; hangup
+ * triggers wrap-up. This is the app-side precondition for the Nivå 3 live-PBX
+ * test (which injects the caller via AMI Originate instead).
+ */
+
+import { test, expect } from './fixtures'
+
+const CALL_CENTER_URL = process.env.CALL_CENTER_URL || 'http://localhost:5174/?test=true'
+
+test.describe('Call-center inbound call flow', () => {
+  test('rings, accepts, and wraps up an incoming call', async ({
+    page,
+    mockSipServer,
+    mockMediaDevices,
+    simulateIncomingCall,
+    browserName,
+  }) => {
+    test.skip(browserName !== 'chromium', 'Smoke is validated in Chromium only')
+
+    await mockSipServer()
+    await mockMediaDevices()
+    await page.goto(CALL_CENTER_URL)
+
+    // Sign in (demo mode — no AMI URL → demo gateway).
+    await expect(page.getByTestId('call-center-login')).toBeVisible()
+    await page.getByTestId('call-center-username').fill('1001')
+    await page.getByTestId('call-center-password').fill('testpassword')
+    await page.getByTestId('call-center-display-name').fill('Agent Inbound')
+    await page.getByTestId('call-center-connect').click()
+    await expect(page.getByTestId('call-center-dashboard')).toBeVisible({ timeout: 15000 })
+
+    await page.getByTestId('agent-status-available').click()
+
+    // Inject a ringing inbound call via the mock SIP transport.
+    await simulateIncomingCall('sip:alice.smith@example.com')
+
+    // The incoming banner must render with Svara/Avvisa buttons.
+    await expect(page.getByTestId('call-center-incoming-banner')).toBeVisible({ timeout: 8000 })
+    await expect(page.getByTestId('call-center-incoming-accept')).toBeVisible()
+    await expect(page.getByTestId('call-center-incoming-reject')).toBeVisible()
+
+    // Accept → the call becomes active (answer() was invoked, not makeCall()).
+    await page.getByTestId('call-center-incoming-accept').click()
+    await expect(page.getByTestId('call-center-active-call')).toBeVisible({ timeout: 10000 })
+
+    // Hang up → wrap-up panel.
+    await page.getByTestId('call-center-hangup').click()
+    await expect(page.getByTestId('call-center-wrap-up')).toBeVisible({ timeout: 10000 })
+
+    await page.getByTestId('wrap-up-disposition').selectOption('resolved')
+    await page.getByTestId('wrap-up-notes').fill('Inbound call resolved')
+    await page.getByTestId('wrap-up-complete').click()
+
+    // Back to available — wrap-up cleared.
+    await expect(page.getByTestId('call-center-dashboard')).toBeVisible({ timeout: 10000 })
+  })
+
+  test('rejecting a ringing call returns to available without an active call', async ({
+    page,
+    mockSipServer,
+    mockMediaDevices,
+    simulateIncomingCall,
+    browserName,
+  }) => {
+    test.skip(browserName !== 'chromium', 'Smoke is validated in Chromium only')
+
+    await mockSipServer()
+    await mockMediaDevices()
+    await page.goto(CALL_CENTER_URL)
+
+    await expect(page.getByTestId('call-center-login')).toBeVisible()
+    await page.getByTestId('call-center-username').fill('1001')
+    await page.getByTestId('call-center-password').fill('testpassword')
+    await page.getByTestId('call-center-display-name').fill('Agent Reject')
+    await page.getByTestId('call-center-connect').click()
+    await expect(page.getByTestId('call-center-dashboard')).toBeVisible({ timeout: 15000 })
+
+    await page.getByTestId('agent-status-available').click()
+    await simulateIncomingCall('sip:bob.jones@example.com')
+
+    await expect(page.getByTestId('call-center-incoming-banner')).toBeVisible({ timeout: 8000 })
+    await page.getByTestId('call-center-incoming-reject').click()
+
+    // No active call should appear; the banner dismisses.
+    await expect(page.getByTestId('call-center-incoming-banner')).toBeHidden({ timeout: 5000 })
+    await expect(page.getByTestId('call-center-active-call')).toBeHidden()
+  })
+})


### PR DESCRIPTION
Closes the inbound-call gap: the call-center example can now answer a SIP INVITE the PBX delivers (not just originate outbound). Adds a ringing banner + answer/reject handlers + AMI↔SIP correlation, and both a mocked e2e (green) and an opt-in live-PBX Nivå 3 test (coded, gated on PBX WSS health).

See commit message for the full breakdown. Verified: vue-tsc clean, 45/45 unit tests, build green, Fas 1 (mocked) e2e 2/2 green. Fas 2 (live PBX) could not run green at commit time — both WSS proxies on wss.telenurse.se were returning 502/503 (intermittent infra issue, not an app bug).